### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,7 @@
 # Workflow for running pre-commit checks, tests, and dependency analysis
 name: pre-commit
+permissions:
+  contents: read
 
 # Trigger this workflow on any push to the repository
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/TinyCTA/security/code-scanning/12](https://github.com/tschm/TinyCTA/security/code-scanning/12)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for all jobs. Based on the workflow's description and the actions used, it seems that only `contents: read` is necessary. This will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, ensuring no unnecessary write permissions are granted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
