### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # Workflow for continuous integration testing across multiple platforms and Python versions
 name: "CI"
+permissions:
+  contents: read
 
 # Trigger this workflow on any push to the repository
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/TinyCTA/security/code-scanning/10](https://github.com/tschm/TinyCTA/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only sets up a Python environment and runs tests, it likely only needs `contents: read` permissions. This change will ensure that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
