### PR TITLE
chore: sync template from jebel-quant/rhiza@main

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 root = true
 

--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Action: Setup Project (composite action)
 #

--- a/.github/scripts/customisations/build-extras.sh
+++ b/.github/scripts/customisations/build-extras.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Optional hook script for installing extra dependencies
 #

--- a/.github/scripts/customisations/post-release.sh
+++ b/.github/scripts/customisations/post-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Optional hook script for post-release actions
 #

--- a/.github/scripts/sync.sh
+++ b/.github/scripts/sync.sh
@@ -5,7 +5,7 @@
 # - Copies them to the current repository
 #
 # This script is POSIX-sh compatible and provides manual sync capability
-# for repositories that use Jebel-Quant/rhiza as a template.
+# for repositories that use jebel-quant/rhiza as a template.
 
 set -e
 
@@ -26,12 +26,12 @@ show_usage() {
   printf "  --dry-run      Show what would be synced without making changes\n\n"
   printf "Configuration:\n"
   printf "  Reads from %s to determine:\n" "$TEMPLATE_CONFIG"
-  printf "  - template-repository: Source repository (e.g., 'Jebel-Quant/rhiza')\n"
+  printf "  - template-repository: Source repository (e.g., 'jebel-quant/rhiza')\n"
   printf "  - template-branch: Branch to sync from (e.g., 'main')\n"
   printf "  - include: Files/directories to sync\n"
   printf "  - exclude: Files/directories to skip (optional)\n\n"
   printf "Example %s:\n" "$TEMPLATE_CONFIG"
-  printf "  template-repository: \"Jebel-Quant/rhiza\"\n"
+  printf "  template-repository: \"jebel-quant/rhiza\"\n"
   printf "  template-branch: \"main\"\n"
   printf "  include: |\n"
   printf "    .github\n"
@@ -63,7 +63,7 @@ if [ ! -f "$TEMPLATE_CONFIG" ]; then
   printf "%b[ERROR] Template configuration not found: %s%b\n" "$RED" "$TEMPLATE_CONFIG" "$RESET"
   printf "\nThis repository is not configured for template syncing.\n"
   printf "Create %s with the following content:\n\n" "$TEMPLATE_CONFIG"
-  printf "  template-repository: \"Jebel-Quant/rhiza\"\n"
+  printf "  template-repository: \"jebel-quant/rhiza\"\n"
   printf "  template-branch: \"main\"\n"
   printf "  include: |\n"
   printf "    .github\n"

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Workflow: Book
 # Purpose: This workflow builds and deploys comprehensive documentation for the project.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Workflow: Continuous Integration
 #

--- a/.github/workflows/deptry.yml
+++ b/.github/workflows/deptry.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Workflow: Deptry
 #

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Devcontainer CI Workflow
 #

--- a/.github/workflows/marimo.yml
+++ b/.github/workflows/marimo.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Workflow: Marimo Notebooks
 #

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Workflow: Pre-commit
 #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Release Workflow for Python Packages with Optional Devcontainer Publishing
 #

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 # Workflow: Sync
 #
@@ -27,7 +27,7 @@ on:
 
 jobs:
   sync:
-    if: ${{ github.repository != 'Jebel-Quant/rhiza' }}
+    if: ${{ github.repository != 'jebel-quant/rhiza' }}
     runs-on: ubuntu-latest
     steps:
       - name: Sync Template

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# This file is part of the Jebel-Quant/rhiza repository
-# (https://github.com/Jebel-Quant/rhiza).
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
 #
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This PR syncs the template from:
**jebel-quant/rhiza @ main**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized repository naming conventions across all project files, updating references from "Jebel-Quant/rhiza" to "jebel-quant/rhiza." Changes applied throughout GitHub Actions workflows, configuration files, shell scripts, pre-commit hooks, and documentation headers. Updated corresponding GitHub repository URLs and all project infrastructure references to maintain consistent lowercase naming standards across the entire project ecosystem.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->