### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.github/workflows/rhiza_benchmarks.yml
+++ b/.github/workflows/rhiza_benchmarks.yml
@@ -37,9 +37,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
           python-version: "3.12"
 
       - name: Run benchmarks

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -41,9 +41,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
 
       - name: "Sync the virtual environment for ${{ github.repository }}"
         shell: bash

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -29,9 +29,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
 
       - id: versions
         env:
@@ -60,9 +60,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
@@ -79,9 +79,9 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
 
       - name: Check docs coverage
         env:

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -91,7 +91,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.31.10
+      uses: github/codeql-action/init@v4.32.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -120,6 +120,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.31.10
+      uses: github/codeql-action/analyze@v4.32.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/rhiza_deptry.yml
+++ b/.github/workflows/rhiza_deptry.yml
@@ -27,7 +27,7 @@ jobs:
     name: Check dependencies with deptry
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/astral-sh/uv:0.9.27-python3.12-trixie
+      image: ghcr.io/astral-sh/uv:0.9.28-bookworm
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -81,9 +81,9 @@ jobs:
 
       # Install uv/uvx
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
 
       # Execute the notebook with the appropriate runner based on its content
       - name: Run notebook

--- a/.github/workflows/rhiza_mypy.yml
+++ b/.github/workflows/rhiza_mypy.yml
@@ -24,7 +24,7 @@ jobs:
     name: Static type checking with mypy
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/astral-sh/uv:0.9.27-python3.12-trixie
+      image: ghcr.io/astral-sh/uv:0.9.28-bookworm
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -111,9 +111,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
 
       - name: Verify version matches tag
         if: hashFiles('pyproject.toml') != ''
@@ -259,7 +259,7 @@ jobs:
 
       - name: Login to Container Registry
         if: steps.check_publish.outputs.should_publish == 'true'
-        uses: docker/login-action@v3.6.0
+        uses: docker/login-action@v3.7.0
         with:
           registry: ${{ steps.registry.outputs.registry }}
           username: ${{ github.repository_owner }}
@@ -320,9 +320,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
         with:
-          version: "0.9.27"
+          version: "0.9.28"
 
       - name: "Sync the virtual environment for ${{ github.repository }}"
         shell: bash
@@ -332,7 +332,7 @@ jobs:
           uv sync --all-extras --all-groups --frozen
 
       - name: Set up Python
-        uses: actions/setup-python@v6.1.0
+        uses: actions/setup-python@v6.2.0
 
       - name: Generate Devcontainer Link
         id: devcontainer_link

--- a/.github/workflows/rhiza_security.yml
+++ b/.github/workflows/rhiza_security.yml
@@ -27,7 +27,7 @@ jobs:
     name: Security scanning
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/astral-sh/uv:0.9.27-python3.12-trixie
+      image: ghcr.io/astral-sh/uv:0.9.28-bookworm
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.2.0
+        uses: astral-sh/setup-uv@v7.2.1
 
       - name: Get Rhiza version
         id: rhiza-version
@@ -90,7 +90,7 @@ jobs:
         if: >
           (github.event_name == 'schedule' || inputs.create-pr == true)
           && steps.sync.outputs.changes_detected == 'true'
-        uses: peter-evans/create-pull-request@v8.0.0
+        uses: peter-evans/create-pull-request@v8.1.0
         with:
           token: ${{ secrets.PAT_TOKEN || github.token }}
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/rhiza_validate.yml
+++ b/.github/workflows/rhiza_validate.yml
@@ -15,7 +15,7 @@ jobs:
     # don't run this in rhiza itself. Rhiza has no template.yml file.
     if: ${{ github.repository != 'jebel-quant/rhiza' }}
     container:
-      image: ghcr.io/astral-sh/uv:0.9.27-python3.12-trixie
+      image: ghcr.io/astral-sh/uv:0.9.28-bookworm
 
     steps:
       - name: Checkout repository

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
         "pep621",
         "pre-commit",
         "github-actions",
+        "gitlabci",
         "devcontainer",
         "dockerfile"
     ],

--- a/tests/test_rhiza/test_makefile.py
+++ b/tests/test_rhiza/test_makefile.py
@@ -153,7 +153,11 @@ class TestMakefile:
 
     def test_fmt_target_dry_run(self, logger, tmp_path):
         """Fmt target should invoke pre-commit via uvx with Python version in dry-run output."""
-        proc = run_make(logger, ["fmt"])
+        # Create clean environment without PYTHON_VERSION so Makefile reads from .python-version
+        env = os.environ.copy()
+        env.pop("PYTHON_VERSION", None)
+
+        proc = run_make(logger, ["fmt"], env=env)
         out = proc.stdout
         # Check for uvx command with the Python version flag
         # The PYTHON_VERSION should be read from .python-version file (e.g., "3.12")
@@ -178,7 +182,12 @@ class TestMakefile:
         env_content += "\nSOURCE_FOLDER=src\n"
         env_file.write_text(env_content)
 
-        proc = run_make(logger, ["deptry"])
+        # Create clean environment without PYTHON_VERSION so Makefile reads from .python-version
+        env = os.environ.copy()
+        env.pop("PYTHON_VERSION", None)
+
+        proc = run_make(logger, ["deptry"], env=env)
+
         out = proc.stdout
         # Check for uvx command with the Python version flag
         python_version_file = tmp_path / ".python-version"


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **13** files modified
- **0** files deleted

### 📁 Changes by Category

#### Configuration Files

<details>
<summary>Modified (1)</summary>

- 📝 `renovate.json`

</details>

#### GitHub Actions Workflows

<details>
<summary>Modified (11)</summary>

- 📝 `.github/workflows/rhiza_benchmarks.yml`
- 📝 `.github/workflows/rhiza_book.yml`
- 📝 `.github/workflows/rhiza_ci.yml`
- 📝 `.github/workflows/rhiza_codeql.yml`
- 📝 `.github/workflows/rhiza_deptry.yml`
- 📝 `.github/workflows/rhiza_marimo.yml`
- 📝 `.github/workflows/rhiza_mypy.yml`
- 📝 `.github/workflows/rhiza_release.yml`
- 📝 `.github/workflows/rhiza_security.yml`
- 📝 `.github/workflows/rhiza_sync.yml`
- 📝 `.github/workflows/rhiza_validate.yml`

</details>

#### Tests

<details>
<summary>Modified (1)</summary>

- 📝 `tests/test_rhiza/test_makefile.py`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-01-30T12:06:43+04:00
- Sync date: 2026-02-02T00:25:51.409228+00:00