### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -115,5 +115,5 @@ files:
 - pytest.ini
 - renovate.json
 - ruff.toml
-synced_at: '2026-04-01T21:12:51Z'
+synced_at: '2026-04-06T00:30:52Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-04-05T05:10:28Z
- Sync date: 2026-04-06T00:30:54.870675+00:00