### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -3,10 +3,7 @@ repo: jebel-quant/rhiza
 host: github
 ref: v0.10.1
 include: []
-exclude:
-- .rhiza/make.d/agentic.mk
-- .rhiza/make.d/gh-aw.mk
-- .rhiza/make.d/github.mk
+exclude: []
 templates:
 - github
 - legal
@@ -92,5 +89,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-04-18T15:37:49Z'
+synced_at: '2026-04-20T00:33:56Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-04-18T19:42:46+04:00
- Sync date: 2026-04-20T00:33:58.603306+00:00