### PR TITLE
Remove osc and returns_adjust functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ A Lightweight Python Package for Commodity Trading Advisor Strategies.
 TinyCTA provides essential tools for quantitative finance and algorithmic trading,
 particularly for trend-following strategies. The package includes:
 
-- Signal processing functions for creating oscillators and adjusting returns
+- Polars-based signal processing: oscillators, moving-average crossovers, and volatility-adjusted returns
+- Robust volatility estimation via rolling median absolute deviation
 - Linear algebra utilities that handle matrices with missing values
 - Matrix shrinkage techniques commonly used in portfolio optimization
 
@@ -51,35 +52,39 @@ virtual environment with all dependencies.
 
 ## 💻 Usage
 
-### Creating an oscillator
+### Oscillator signal (Polars)
 
 ```python
-from pathlib import Path
+import polars as pl
+from tinycta.osc import osc
 
-import pandas as pd
-from tinycta.signal import osc
-
-path = Path(__name__).resolve().parent.parent
-
-# Load price data
-prices = pd.read_csv("data.csv", index_col=0, parse_dates=True)
-
-# Create an oscillator with default parameters
-oscillator = prices.apply(osc)
-
-# Create an oscillator with custom parameters
-custom_oscillator = prices.apply(osc, fast=16, slow=64, scaling=False)
+prices = pl.DataFrame({"A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
+result = prices.with_columns(osc(pl.col("A"), fast=2, slow=6, vola=3).alias("osc_A"))
 ```
 
-### Adjusting returns for volatility
-
-<!--pytest-codeblocks:cont-->
+### Moving-average crossover (Polars)
 
 ```python
-from tinycta.signal import returns_adjust
+import polars as pl
+from tinycta.ewma import ma_cross
 
-# Adjust returns for volatility
-adjusted_returns = prices.apply(returns_adjust)
+prices = pl.DataFrame({"A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
+result = prices.with_columns(
+    ma_cross(pl.col("A"), fast=2, slow=6).alias("sig_A")
+)
+```
+
+### Volatility-adjusted returns (Polars)
+
+```python
+import polars as pl
+from tinycta.util import vol_adj, adj_log_prices
+
+prices = pl.DataFrame({"A": [100, 101, 99, 102, 98, 103]})
+result = prices.with_columns(
+    vol_adj(pl.col("A"), vola=3, clip=4.2).alias("vol_adj_A"),
+    adj_log_prices(pl.col("A"), vola=3, clip=4.2).alias("adj_log_A"),
+)
 ```
 
 ### Linear algebra operations
@@ -88,11 +93,8 @@ adjusted_returns = prices.apply(returns_adjust)
 import numpy as np
 from tinycta.linalg import solve
 
-# Create a matrix and right-hand side vector
 matrix = np.array([[1.0, 0.5], [0.5, 1.0]])
 rhs = np.array([1.0, 2.0])
-
-# Solve the linear system
 solution = solve(matrix, rhs)
 print(solution)
 ```
@@ -103,24 +105,24 @@ print(solution)
 
 ## 📚 API Reference
 
-### Signal Processing
+### Signal Processing (`tinycta.osc`, `tinycta.ewma`, `tinycta.util`)
 
-- `osc(prices, fast=32, slow=96, scaling=True)`:
-   Creates an oscillator based on the difference between fast and slow moving averages
-- `returns_adjust(price, com=32, min_periods=300, clip=4.2)`:
-   Adjusts log-returns by volatility and applies winsorization
-- `shrink2id(matrix, lamb=1.0)`:
-   Performs shrinkage of a matrix towards the identity matrix
+- `osc(x, fast, slow, vola, min_samples=1)` — EWMA-difference oscillator scaled by EWMA volatility (Polars)
+- `ma_cross(prices, fast, slow, min_samples=1)` — sign of fast-vs-slow EWM crossover: -1, 0, or +1 (Polars)
+- `vol_adj(x, vola, clip, min_samples=1)` — clipped, volatility-adjusted log returns (Polars)
+- `adj_log_prices(x, vola, clip, min_samples=1)` — cumulative sum of volatility-adjusted log returns (Polars)
 
-### Linear Algebra
+### Signal Utilities (`tinycta.signal`)
 
-- `valid(matrix)`:
-Constructs a valid subset of a matrix by filtering out rows/columns with NaN values
-- `a_norm(vector, matrix=None)`:
-Computes the matrix-norm of a vector with respect to a matrix
-- `inv_a_norm(vector, matrix=None)`: Computes the inverse matrix-norm of a vector
-- `solve(matrix, rhs)`:
-Solves a linear system of equations, handling matrices with NaN values
+- `moving_absolute_deviation(price, com=32)` — robust rolling volatility estimate via median absolute deviation (pandas)
+- `shrink2id(matrix, lamb=1.0)` — shrink a matrix towards the identity matrix
+
+### Linear Algebra (`tinycta.linalg`)
+
+- `valid(matrix)` — extract the finite subset of a matrix by filtering NaN rows/columns
+- `a_norm(vector, matrix=None)` — matrix-norm of a vector
+- `inv_a_norm(vector, matrix=None)` — inverse matrix-norm of a vector
+- `solve(matrix, rhs)` — solve a linear system, handling matrices with NaN values
 
 ## 🛠️ Development
 

--- a/src/tinycta/signal.py
+++ b/src/tinycta/signal.py
@@ -21,51 +21,6 @@ import numpy as np
 import pandas as pd
 
 
-def osc(prices: pd.DataFrame, fast: int = 32, slow: int = 96, scaling: bool = True) -> pd.DataFrame:
-    """Compute the oscillator for a given financial price data.
-
-    Use Exponential Weighted Moving Averages (EWM). The calculation involves
-    the difference between fast and slow EWM means, optionally scaled by the
-    standard deviation.
-
-    Args:
-        prices: DataFrame containing the price data used for the oscillator computation.
-        fast: The time period for the fast EWM calculation. Default is 32.
-        slow: The time period for the slow EWM calculation. Default is 96.
-        scaling: If True, the difference will be scaled using its standard deviation.
-            If False, scaling is skipped. Default is True.
-
-    Returns:
-        DataFrame containing the computed oscillator values.
-    """
-    diff = prices.ewm(com=fast - 1).mean() - prices.ewm(com=slow - 1).mean()
-    s = diff.std() if scaling else 1
-
-    return diff / s
-
-
-def returns_adjust(price: pd.DataFrame, com: int = 32, min_periods: int = 300, clip: float = 4.2) -> pd.DataFrame:
-    """Calculate and adjust log returns for a given price DataFrame.
-
-    Computes the logarithmic returns, normalizes them using exponentially
-    weighted moving standard deviation, and clips the resulting values to a
-    specified range.
-
-    Args:
-        price: DataFrame containing price data for which log returns will be calculated.
-        com: Center of mass for the exponentially weighted moving average. Default is 32.
-        min_periods: Minimum number of periods required for the EWMA standard deviation
-            to be valid. Default is 300.
-        clip: Absolute value threshold to which the adjusted returns are clipped.
-            Default is 4.2.
-
-    Returns:
-        A DataFrame of normalized and clipped log returns for the input price data.
-    """
-    r = price.apply(np.log).diff()
-    return (r / r.ewm(com=com, min_periods=min_periods).std()).clip(-clip, +clip)
-
-
 def moving_absolute_deviation(price: pd.DataFrame, com: int = 32) -> pd.DataFrame:
     """Compute the rolling median absolute deviation (MAD) of log returns.
 

--- a/tests/test_tiny_cta/test_signal.py
+++ b/tests/test_tiny_cta/test_signal.py
@@ -1,9 +1,4 @@
-"""Tests for the signal processing module of TinyCTA.
-
-This module contains tests for the signal processing functions in the TinyCTA package.
-It tests the functionality of matrix shrinkage, returns adjustment, and oscillator calculations
-with various parameters to ensure they produce the expected results.
-"""
+"""Tests for the signal processing module of TinyCTA."""
 
 from __future__ import annotations
 
@@ -11,84 +6,18 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tinycta.signal import moving_absolute_deviation, osc, returns_adjust, shrink2id
+from tinycta.signal import moving_absolute_deviation, shrink2id
 
 
 def test_moving_absolute_deviation(prices: pd.DataFrame) -> None:
-    """Test the moving_absolute_deviation function as a robust alternative to moving variance.
-
-    This test verifies that the moving_absolute_deviation function correctly computes
-    the rolling median absolute deviation of log returns and that the result is
-    non-negative and finite for valid periods.
-
-    Args:
-        prices: DataFrame fixture containing price data for testing.
-    """
+    """Test moving_absolute_deviation returns non-negative values."""
     mad = prices.apply(moving_absolute_deviation)
-    # Result should be non-negative (absolute deviations are always >= 0)
     assert (mad.dropna() >= 0).all().all()
-    # Check a specific value for regression testing
     assert mad.std()["-9186993121995610806"] == pytest.approx(0.000859190064724947)
 
-    """Test the shrink2id function for matrix shrinkage towards identity.
 
-    This test verifies that the shrink2id function correctly performs linear shrinkage
-    of a matrix towards the identity matrix using the specified lambda parameter.
-
-    The test creates a matrix of all 1.0s and applies shrinkage with lambda=0.3,
-    then checks that the result has 1.0s on the diagonal and 0.3s elsewhere.
-    """
+def test_shrink2id() -> None:
+    """Test shrink2id shrinks off-diagonal elements by lambda."""
     matrix = np.array([[1.0, 1.0], [1.0, 1.0]])
     s = shrink2id(matrix=matrix, lamb=0.3)
     np.testing.assert_array_equal(s, np.array([[1.0, 0.3], [0.3, 1.0]]))
-
-
-def test_returns_adjust(prices: pd.DataFrame) -> None:
-    """Test the returns_adjust function for volatility adjustment.
-
-    This test verifies that the returns_adjust function correctly calculates
-    volatility-adjusted log returns from price data.
-
-    Args:
-        prices: DataFrame fixture containing price data for testing.
-
-    The test applies the returns_adjust function to the prices DataFrame with
-    a minimum period of 2, then checks that the standard deviation of a specific
-    column matches the expected value.
-    """
-    r = prices.apply(returns_adjust, min_periods=2)
-    assert r.std()["-9186993121995610806"] == pytest.approx(0.9771085360599361)
-
-
-def test_osc_scaling(prices: pd.DataFrame) -> None:
-    """Test the oscillator function with scaling enabled.
-
-    This test verifies that the osc function correctly calculates the oscillator
-    with scaling enabled, which should normalize the standard deviation to 1.0.
-
-    Args:
-        prices: DataFrame fixture containing price data for testing.
-
-    The test applies the osc function to the prices DataFrame with default parameters
-    (scaling=True), then checks that the standard deviation of a specific column
-    is exactly 1.0, confirming proper scaling.
-    """
-    x = prices.apply(osc)
-    assert x.std()["-9186993121995610806"] == 1.0
-
-
-def test_osc_no_scaling(prices: pd.DataFrame) -> None:
-    """Test the oscillator function with scaling disabled.
-
-    This test verifies that the osc function correctly calculates the oscillator
-    with scaling disabled, which should preserve the original standard deviation.
-
-    Args:
-        prices: DataFrame fixture containing price data for testing.
-
-    The test applies the osc function to the prices DataFrame with scaling=False,
-    then checks that the standard deviation of a specific column matches the
-    expected unscaled value.
-    """
-    x = prices.apply(osc, scaling=False)
-    assert x.std()["-9186993121995610806"] == pytest.approx(1.7559634754674203)


### PR DESCRIPTION
Removed osc and returns_adjust functions from signal.py, which computed oscillator and adjusted log returns respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed oscillator signal computation utility
  * Removed adjusted log-return calculation utility

Please note these changes remove previously available signal processing functions. If your workflows depend on these utilities, alternative approaches may be needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->