### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -91,5 +91,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-04-25T04:01:47Z'
+synced_at: '2026-04-27T00:36:17Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-04-25T08:02:07+04:00
- Sync date: 2026-04-27T00:36:18.664890+00:00