### PR TITLE
refactor(signal): replace pandas with polars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "loguru>=0.7.3",
     "numpy>=2.0.0",
     "optuna>=4.8.0",
-    "pandas>=2.2.3",
     "polars>=1.0.0",
     "pydantic>=2.13.3",
     "pyyaml>=6.0.3",
@@ -25,6 +24,7 @@ dev = [
     "pre-commit==4.6.0",
     "marimo==0.23.6",
     "plotly>=6.5",
+    "pandas>=2.2.3",
     "pandas-stubs>=2.2",
 ]
 
@@ -40,7 +40,6 @@ cvx-linalg = "cvx"
 loguru = "loguru"
 numpy = "numpy"
 optuna = "optuna"
-pandas = "pandas"
 pandas-stubs = []
 polars = "polars"
 pre-commit = "pre_commit"

--- a/src/tinycta/signal.py
+++ b/src/tinycta/signal.py
@@ -17,11 +17,13 @@ used to generate trading signals from price data.
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
-import pandas as pd
+import polars as pl
 
 
-def moving_absolute_deviation(price: pd.DataFrame, com: int = 32) -> pd.DataFrame:
+def moving_absolute_deviation(x: pl.Expr, com: int = 32) -> pl.Expr:
     """Compute the rolling median absolute deviation (MAD) of log returns.
 
     A robust alternative to moving standard deviation, less sensitive to outliers.
@@ -30,16 +32,16 @@ def moving_absolute_deviation(price: pd.DataFrame, com: int = 32) -> pd.DataFram
     under normality.
 
     Args:
-        price: DataFrame containing price data.
+        x: Polars expression representing the price series.
         com: Center of mass used to derive the rolling window as ``window = 2 * com - 1``.
 
     Returns:
-        DataFrame of scaled rolling MAD values consistent with std under normality.
+        Polars expression of scaled rolling MAD values consistent with std under normality.
     """
-    r = price.apply(np.log).diff()
     window = 2 * com - 1
-    rolling_median = r.rolling(window=window).median()
-    return (r - rolling_median).abs().rolling(window=window).median() / 0.6745
+    r = x.log(base=math.e).diff()
+    rolling_median = r.rolling_median(window_size=window)
+    return (r - rolling_median).abs().rolling_median(window_size=window) / 0.6745
 
 
 def shrink2id(matrix: np.ndarray, lamb: float = 1.0) -> np.ndarray:

--- a/tests/test_tiny_cta/conftest.py
+++ b/tests/test_tiny_cta/conftest.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 import pytest
 
 
@@ -30,7 +30,7 @@ def resource_fixture() -> Path:
 
 
 @pytest.fixture
-def prices(resource_dir: Path) -> pd.DataFrame:
+def prices(resource_dir: Path) -> pl.DataFrame:
     """Provide a DataFrame of price data for testing.
 
     This fixture loads price data from a CSV file with hashed column names.
@@ -40,6 +40,7 @@ def prices(resource_dir: Path) -> pd.DataFrame:
         resource_dir: Path fixture pointing to the resources directory.
 
     Returns:
-        pd.DataFrame: A DataFrame containing price data with datetime index.
+        pl.DataFrame: A DataFrame containing price data with a date column.
     """
-    return pd.read_csv(resource_dir / "prices_hashed.csv", index_col=0, header=0, parse_dates=True)
+    df = pl.read_csv(resource_dir / "prices_hashed.csv", try_parse_dates=True)
+    return df.rename({df.columns[0]: "date"})

--- a/tests/test_tiny_cta/test_signal.py
+++ b/tests/test_tiny_cta/test_signal.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
+import polars as pl
 import pytest
 
 from tinycta.signal import moving_absolute_deviation, shrink2id
 
 
-def test_moving_absolute_deviation(prices: pd.DataFrame) -> None:
+def test_moving_absolute_deviation(prices: pl.DataFrame) -> None:
     """Test moving_absolute_deviation returns non-negative values."""
-    mad = prices.apply(moving_absolute_deviation)
-    assert (mad.dropna() >= 0).all().all()
-    assert mad.std()["-9186993121995610806"] == pytest.approx(0.000859190064724947)
+    asset_cols = [c for c in prices.columns if c != "date"]
+    mad = prices.with_columns([moving_absolute_deviation(pl.col(c)).alias(c) for c in asset_cols])
+    mad_assets = mad.select(asset_cols).drop_nulls()
+    assert mad_assets.select(pl.all() >= 0).select(pl.all_horizontal(pl.all())).to_series().all()
+    assert mad.select(pl.col("-9186993121995610806").std()).item() == pytest.approx(0.000859190064724947)
 
 
 def test_shrink2id() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1237,7 +1237,6 @@ dependencies = [
     { name = "loguru" },
     { name = "numpy" },
     { name = "optuna" },
-    { name = "pandas" },
     { name = "polars" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -1246,6 +1245,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "marimo" },
+    { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "plotly" },
     { name = "pre-commit" },
@@ -1257,7 +1257,6 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "optuna", specifier = ">=4.8.0" },
-    { name = "pandas", specifier = ">=2.2.3" },
     { name = "polars", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -1266,6 +1265,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "marimo", specifier = "==0.23.6" },
+    { name = "pandas", specifier = ">=2.2.3" },
     { name = "pandas-stubs", specifier = ">=2.2" },
     { name = "plotly", specifier = ">=6.5" },
     { name = "pre-commit", specifier = "==4.6.0" },


### PR DESCRIPTION
## Summary

- Rewrites `moving_absolute_deviation` in `signal.py` to accept a `pl.Expr` and return a `pl.Expr`, consistent with the rest of the package (`osc`, `util`, `ewma`)
- Removes `pandas` from core dependencies; moves it to the dev group (still needed by the `test_ewm_cov` pandas-comparison test)
- Updates the `prices` fixture in `conftest.py` to return a `pl.DataFrame` via `pl.read_csv`
- Updates `test_signal.py` to use the Polars expression API

## Test plan

- [x] `test_moving_absolute_deviation` passes with the same numeric assertion (`std ≈ 0.000859190064724947`)
- [x] All 66 tests pass (`pytest tests/test_tiny_cta/`)
- [x] Pre-commit hooks pass (ruff, bandit, uv-lock, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Core signal processing function reimplemented with an alternative technical approach, enhancing code maintainability and long-term extensibility
  * Complete test suite and fixtures updated to work seamlessly with refactored components
  * Development dependencies reorganized for improved project structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/TinyCTA/pull/735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->