### PR TITLE
chore: update rhiza to v0.15.3

### DIFF
--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.15.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -21,5 +21,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.15.2
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -29,5 +29,5 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.15.2
     secrets: inherit

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.15.2
     secrets: inherit

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -79,6 +79,6 @@ permissions:
 
 jobs:
   release:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_release.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_release.yml@v0.15.2
     secrets: inherit
 

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.15.2
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.15.2
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 2bc1c8262d292c3304496e2c4352f11b5c2b32fa
+sha: 8020ad01ac1ab64cfa5abb9915f44af9fbd0ede7
 repo: jebel-quant/rhiza
 host: github
-ref: v0.15.1
+ref: v0.15.2
 include: []
 exclude: []
 templates:
@@ -102,5 +102,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-05-26T06:34:08Z'
+synced_at: '2026-05-26T12:43:24Z'
 strategy: merge

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 8020ad01ac1ab64cfa5abb9915f44af9fbd0ede7
+sha: 4051814fc1976da3a86cefa499be5bada21eb674
 repo: jebel-quant/rhiza
 host: github
-ref: v0.15.2
+ref: v0.15.3
 include: []
 exclude: []
 templates:
@@ -102,5 +102,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-05-26T12:43:24Z'
+synced_at: '2026-05-26T14:39:38Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.15.2"
+ref: "v0.15.3"
 
 profiles:
   - github-project

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.15.1"
+ref: "v0.15.2"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary

- Bumps `template-branch` to `v0.15.3` in `.rhiza/template.yml`
- Bumps `.rhiza/.rhiza-version` to `0.16.1`
- Runs `make sync` to apply upstream template changes
