### PR TITLE
fix: address P0 repo-quality gaps (#760, #761, #762)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "TinyCTA"
 version = "0.13.2"
-description = "..."
+description = "A lightweight Python package for Commodity Trading Advisor (CTA) strategies"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/tinycta/config.py
+++ b/src/tinycta/config.py
@@ -19,5 +19,6 @@ class Config(BaseModel):
         """Enforce corr >= vola for numerical stability."""
         vola = info.data.get("vola") if hasattr(info, "data") else None
         if vola is not None and v < vola:
-            raise ValueError
+            msg = f"corr ({v}) must be >= vola ({vola}) for numerical stability"
+            raise ValueError(msg)
         return v

--- a/src/tinycta/engine.py
+++ b/src/tinycta/engine.py
@@ -26,13 +26,17 @@ class Engine:
     def __post_init__(self) -> None:
         """Validate that prices and mu are aligned and both contain a date column."""
         if "date" not in self.prices.columns:
-            raise ValueError
+            msg = "prices must contain a 'date' column"
+            raise ValueError(msg)
         if "date" not in self.mu.columns:
-            raise ValueError
+            msg = "mu must contain a 'date' column"
+            raise ValueError(msg)
         if self.prices.shape != self.mu.shape:
-            raise ValueError
-        if not set(self.prices.columns) == set(self.mu.columns):
-            raise ValueError
+            msg = f"prices and mu must share the same shape, got {self.prices.shape} and {self.mu.shape}"
+            raise ValueError(msg)
+        if set(self.prices.columns) != set(self.mu.columns):
+            msg = "prices and mu must share identical columns"
+            raise ValueError(msg)
 
     @property
     def assets(self) -> list[str]:

--- a/src/tinycta/hyper/_study.py
+++ b/src/tinycta/hyper/_study.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import contextlib
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import optuna
 from jquantstats import Portfolio
+from loguru import logger
 
 
 @dataclass(frozen=True)
@@ -58,8 +58,11 @@ class Study:
         }
         for name, fig in figures.items():
             fig.write_html(str(output_dir / f"{name}.html"))
-            with contextlib.suppress(Exception):
+            try:
                 fig.write_image(str(output_dir / f"{name}.png"), scale=2)
+            except (ValueError, ImportError) as exc:
+                # PNG export needs the optional `kaleido` backend; skip if unavailable.
+                logger.debug(f"Skipping PNG export for {name}: {exc}")
 
 
 def _sharpe(portfolio: Portfolio) -> float:

--- a/tests/test_tiny_cta/test_hyper_study.py
+++ b/tests/test_tiny_cta/test_hyper_study.py
@@ -80,13 +80,14 @@ def test_sharpe_raises_on_nan(mocker):
 
 
 def test_study_plot_writes_html_and_swallows_image_error(mocker, tmp_path):
-    """Plot writes HTML for each figure and silently ignores write_image failures."""
+    """Plot writes HTML for each figure and skips write_image failures (missing kaleido)."""
     s = optuna.create_study(direction="maximize")
     s.optimize(lambda trial: float(trial.suggest_int("x", 0, 5)), n_trials=1)
     study = Study.from_optuna(s)
 
     mock_fig = mocker.MagicMock()
-    mock_fig.write_image.side_effect = Exception("kaleido not installed")
+    # plotly raises ValueError when the optional kaleido image backend is missing.
+    mock_fig.write_image.side_effect = ValueError("kaleido not installed")
     for fn in (
         "optuna.visualization.plot_optimization_history",
         "optuna.visualization.plot_param_importances",


### PR DESCRIPTION
Closes the three **P0** sub-issues under #759.

## Changes
- **#760** — `pyproject.toml`: replace the `description = "..."` placeholder (published to PyPI as the package summary) with a real one-liner.
- **#761** — Add diagnostic messages to bare `raise ValueError`:
  - `config.py` — `corr >= vola` validator now reports both values.
  - `engine.py` — each `__post_init__` check (missing `date` column, shape mismatch, column mismatch) now has a specific message.
- **#762** — `hyper/_study.py`: narrow the `contextlib.suppress(Exception)` around `fig.write_image` to `(ValueError, ImportError)` and `logger.debug` the skip, so only the expected missing-kaleido case is swallowed and it's observable.

## Verification
- `make test` → **84 passed, 100% coverage** maintained.
- ruff check + format clean; full pre-commit suite passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for configuration and engine validation failures with specific details.
  * Improved PNG export handling to gracefully handle missing optional dependencies with debug logging.

* **Tests**
  * Updated tests to reflect improved error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->