### PR TITLE
docs: fix doc accuracy for current API (#763, #764)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-TinyCTA is a lightweight Python package for Commodity Trading Advisor (CTA) strategies. It provides signal processing functions for trend-following strategies and linear algebra utilities that handle matrices with missing values.
+TinyCTA is a lightweight Python package for Commodity Trading Advisor (CTA) strategies. It provides
+Polars-based signal-processing expressions for trend-following strategies, a correlation-aware
+position-sizing engine, linear-algebra utilities that handle matrices with missing values, and an
+Optuna-based hyperparameter-optimisation layer.
 
 ## Development Commands
 
@@ -20,44 +23,68 @@ make marimo     # Start Marimo notebook server
 
 To run a single test file:
 ```bash
-.venv/bin/python -m pytest tests/test_tiny_cta/test_signal.py
+.venv/bin/python -m pytest tests/test_tiny_cta/test_osc.py
 ```
 
 To run a specific test:
 ```bash
-.venv/bin/python -m pytest tests/test_tiny_cta/test_signal.py::test_name -v
+.venv/bin/python -m pytest tests/test_tiny_cta/test_osc.py::test_name -v
 ```
 
 ## Project Structure
 
 - `src/tinycta/` - Main package source code
-  - `signal.py` - Signal processing: `osc()` (oscillator), `returns_adjust()`, `shrink2id()`
-  - `linalg.py` - Linear algebra utilities: `valid()`, `a_norm()`, `inv_a_norm()`, `solve()`
+  - `osc.py` - `osc()` analytically scaled EWMA-difference oscillator (Polars expression)
+  - `ewma.py` - `ma_cross()` sign of a fast-vs-slow EWM moving-average crossover (Polars expression)
+  - `util.py` - `vol_adj()` and `adj_log_prices()` volatility-adjusted log returns (Polars expressions)
+  - `signal.py` - `moving_absolute_deviation()` robust rolling volatility and `shrink2id()` matrix shrinkage
+  - `linalg.py` - re-exports `valid()`, `a_norm()`, `inv_a_norm()`, `solve()` from `cvx.linalg`
+  - `ewm_cov.py` - re-exports `ewm_covariance()` and `NegativeWarmupError` from `cvx.linalg.ewm_cov`
+  - `config.py` - `Config`, a frozen Pydantic model validating the engine parameters
+  - `engine.py` - `Engine`, the correlation-aware risk/cash position optimizer ("Basanos" engine)
+  - `hyper/` - Optuna-based hyperparameter optimisation
+    - `_study.py` - frozen `Study` result wrapper and `optimize()` entry point
+    - `_setup.py` - `get_config()` / `ExperimentConfig` notebook experiment setup helpers
 - `tests/test_tiny_cta/` - Package tests
-- `tests/test_rhiza/` - Rhiza framework infrastructure tests
+- `tests/property/` - Hypothesis property-based tests
+- `.rhiza/tests/` - Rhiza framework infrastructure tests
 - `book/` - Documentation source
 - `.rhiza/` - Rhiza framework scripts and configurations
 
 ## Architecture Notes
 
-The package has two core modules:
+The package is organised in three layers:
 
-1. **signal.py** - Functions for trend-following signal generation:
-   - Uses pandas EWM (exponentially weighted moving) for oscillator calculations
-   - Returns volatility-adjusted using log returns and clipping
+1. **Signal expressions** (`osc.py`, `ewma.py`, `util.py`, `signal.py`) - composable Polars
+   expressions for use inside `DataFrame.with_columns`. They build on `ewm_mean`/`ewm_std` and
+   operate column-wise. `signal.py` additionally provides a pandas-free robust volatility estimate
+   (median absolute deviation) and identity-shrinkage of a matrix.
 
-2. **linalg.py** - Linear algebra operations that handle NaN values:
-   - `valid()` extracts the finite subset of a matrix by checking diagonal elements
-   - All functions (`a_norm`, `inv_a_norm`, `solve`) use `valid()` to work with partial data
+2. **Linear algebra** (`linalg.py`, `ewm_cov.py`) - thin re-exports of `cvx.linalg`. These operations
+   tolerate NaN values: `valid()` extracts the finite subset of a matrix, and `a_norm`, `inv_a_norm`,
+   and `solve` work on that partial data.
+
+3. **Engine** (`config.py`, `engine.py`) - `Engine` consumes aligned `prices` and `mu` Polars
+   DataFrames plus a validated `Config` and produces correlation-shrinkage-optimized cash positions.
+   It combines volatility adjustment, EWMA correlation matrices, identity shrinkage, and the linalg
+   solver, scaling positions by a running profit-variance estimate.
+
+The optional **hyper** layer (`hyper/`) wraps Optuna: `optimize()` runs a study over a
+portfolio-returning function scored by Sharpe ratio and returns a frozen `Study`.
 
 ## Dependencies
 
-Core: `numpy>=2.0.0`, `pandas>=2.2.3`
+Core: `cvx-linalg`, `loguru`, `numpy>=2.0.0`, `jquantstats`, `optuna`, `polars`, `pydantic`, `pyyaml`
 
-Dev: `pre-commit`, `marimo`, `plotly`
+Dev: `pre-commit`, `marimo`, `pandas`, `pandas-stubs`
+
+Test: `pytest`, `pytest-cov`, `pytest-html`, `pytest-mock`, `pytest-xdist`, `pytest-timeout`,
+`hypothesis`, `pytest-benchmark`
 
 Managed via `uv add` and `pyproject.toml`.
 
 ## Rhiza Framework
 
-This project uses the Rhiza framework for standardized Python development. The main Makefile includes `.rhiza/rhiza.mk` which provides common targets. Do not modify `.rhiza/` files directly - they are template-managed.
+This project uses the Rhiza framework for standardized Python development. The main Makefile includes
+`.rhiza/rhiza.mk` which provides common targets. Do not modify `.rhiza/` files directly - they are
+template-managed.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,45 @@ print(np.round(solution, 10) + 0)
 [0. 2.]
 ```
 
+### Position-sizing engine
+
+The `Engine` turns aligned price and expected-return (`mu`) frames into
+correlation-shrinkage-optimized cash positions. It is configured by a validated `Config`.
+
+```python +RHIZA_SKIP
+import polars as pl
+from tinycta.config import Config
+from tinycta.engine import Engine
+
+prices = pl.DataFrame({"date": [1, 2, 3, 4], "A": [100.0, 101.0, 102.0, 103.0]})
+mu = pl.DataFrame({"date": [1, 2, 3, 4], "A": [0.0, 0.1, 0.2, 0.1]})
+
+cfg = Config(vola=2, corr=2, clip=4.2, shrink=0.5)
+engine = Engine(prices=prices, mu=mu, cfg=cfg)
+positions = engine.cash_position  # Polars DataFrame of per-asset cash positions
+```
+
+`Config` is a frozen Pydantic model: `vola`, `corr` (must be `>= vola`) and `clip` must be
+positive, and `shrink` must lie in `[0, 1]`.
+
+### Hyperparameter optimization
+
+`tinycta.hyper.optimize` runs an Optuna study over a function that builds a portfolio from a
+trial and scores it by Sharpe ratio, returning a frozen `Study`.
+
+```python +RHIZA_SKIP
+from tinycta.hyper import optimize
+
+def suggest_portfolio(trial):
+    fast = trial.suggest_int("fast", 2, 20)
+    slow = trial.suggest_int("slow", fast + 1, 100)
+    # ... build and return a jquantstats Portfolio from the suggested params ...
+    return build_portfolio(fast, slow)
+
+study = optimize(suggest_portfolio, n_trials=100, seed=42)
+print(study.best_params, study.best_value)
+```
+
 ## 📚 API Reference
 
 ### Signal Processing (`tinycta.osc`, `tinycta.ewma`, `tinycta.util`)
@@ -123,6 +162,17 @@ print(np.round(solution, 10) + 0)
 - `a_norm(vector, matrix=None)` — matrix-norm of a vector
 - `inv_a_norm(vector, matrix=None)` — inverse matrix-norm of a vector
 - `solve(matrix, rhs)` — solve a linear system, handling matrices with NaN values
+
+### Position-Sizing Engine (`tinycta.engine`, `tinycta.config`)
+
+- `Config(vola, corr, clip, shrink)` — frozen Pydantic config; `corr >= vola`, `vola`/`corr`/`clip > 0`, `shrink ∈ [0, 1]`
+- `Engine(prices, mu, cfg)` — correlation-aware position optimizer; `.cash_position` returns per-asset cash positions
+  - `.assets`, `.ret_adj`, `.vola`, `.cor` — intermediate per-asset/per-timestamp quantities
+
+### Hyperparameter Optimization (`tinycta.hyper`)
+
+- `optimize(suggest_portfolio_fn, n_trials=100, seed=42)` — run an Optuna study scored by Sharpe; returns a `Study`
+- `Study` — frozen result wrapper exposing `best_params`, `best_value`, `n_completed`, `n_trials`, and `.plot(output_dir)`
 
 ## 🛠️ Development
 


### PR DESCRIPTION
Closes the two **P1** sub-issues under #759. Docs-only — no code changes, independent of #768.

## Changes
- **#763** — Rewrote `CLAUDE.md`. The old version described a pandas-EWM API and functions (`returns_adjust()`, `osc()` in `signal.py`) that no longer exist. Updated:
  - module map (`osc.py`, `ewma.py`, `util.py`, `signal.py`, `linalg.py`, `ewm_cov.py`, `config.py`, `engine.py`, `hyper/`),
  - architecture notes (signal expressions / linalg re-exports / engine / optional hyper layer),
  - dependency list (cvx-linalg, loguru, numpy, jquantstats, optuna, polars, pydantic, pyyaml; correct dev/test groups),
  - test-directory paths (`tests/property/`, `.rhiza/tests/`) and single-test examples.
- **#764** — Documented the previously-undocumented public surface in `README.md`:
  - usage examples for the `Engine`/`Config` position-sizing layer and the `tinycta.hyper.optimize` Optuna layer,
  - matching API-reference entries.
  - Illustrative snippets are marked `+RHIZA_SKIP` so the README-execution test doesn't run fragile/placeholder code.

## Verification
- `pytest .rhiza/tests/sync/test_readme_validation.py` → **9 passed**.
- markdownlint pre-commit hook passed on both files; full pre-commit suite passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)