### PR TITLE
chore: P2 polish — optional hyper extra, engine docstring, signal property tests (#765, #766, #767)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ in just a few lines of code, hence the name "TinyCTA".
 pip install tinycta
 ```
 
+The core install keeps a minimal dependency footprint (numpy, polars, pydantic, cvx-linalg).
+The optional Optuna-based hyperparameter-optimisation layer (`tinycta.hyper`) is installed via
+the `hyper` extra:
+
+```bash
+pip install "tinycta[hyper]"
+```
+
 ### From source
 
 Clone the repository and install using the provided Makefile:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,17 @@ dev = [
     "marimo==0.23.9",
     "pandas>=2.2.3",
     "pandas-stubs>=2.2",
+    # The `hyper` optional extra is not part of the default sync, but the dev/CI
+    # environment needs it so the tinycta.hyper test suite can be collected and run.
+    {include-group = "hyper"},
+]
+# Mirrors the [project.optional-dependencies] hyper extra so `uv sync` (which
+# installs the dev group by default) provides it for development and CI.
+hyper = [
+    "jquantstats>=0.8.0",
+    "loguru>=0.7.3",
+    "optuna>=4.8.0",
+    "pyyaml>=6.0.3",
 ]
 test = [
     "pytest>=8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,21 @@ classifiers = [
 ]
 dependencies = [
     "cvx-linalg>=0.5.1",
-    "loguru>=0.7.3",
     "numpy>=2.0.0",
-    "jquantstats>=0.8.0",
-    "optuna>=4.8.0",
     "polars>=1.21.0",
     "pydantic>=2.13.3",
+]
+
+[project.optional-dependencies]
+# Hyperparameter-optimisation and notebook-experiment layer (tinycta.hyper).
+# Install with: pip install tinycta[hyper]
+hyper = [
+    "jquantstats>=0.8.0",
+    "loguru>=0.7.3",
+    "optuna>=4.8.0",
     "pyyaml>=6.0.3",
 ]
+
 [project.urls]
 Homepage = "https://github.com/tschm/tinycta"
 Repository = "https://github.com/tschm/tinycta"

--- a/src/tinycta/engine.py
+++ b/src/tinycta/engine.py
@@ -76,7 +76,38 @@ class Engine:
 
     @property
     def cash_position(self) -> pl.DataFrame:
-        """Correlation-shrinkage-optimized cash positions for each timestamp."""
+        """Correlation-shrinkage-optimized cash positions for each timestamp.
+
+        Walks forward through time, and at each timestamp ``t``:
+
+        1. **Mask** assets with a finite price at ``t`` so the optimisation only
+           sees currently-tradable instruments.
+        2. **Shrink** the EWMA correlation matrix towards the identity by
+           ``cfg.shrink`` (via :func:`~tinycta.signal.shrink2id`) for numerical
+           stability, then restrict it to the masked assets.
+        3. **Solve** the shrunk system for the expected returns ``mu`` and
+           normalise by ``inv_a_norm(mu, matrix)`` so the raw risk position has
+           unit norm under the correlation metric (zeroed when the denominator
+           is non-finite/degenerate or ``mu`` is all-zero).
+        4. **Scale** the risk position by a running EWMA estimate of realised
+           profit variance (decay ``lamb=0.99``), which down-weights positions
+           after volatile P&L, then divide by per-asset EWMA volatility
+           (``self.vola``) to convert the risk position into a cash position.
+
+        Returns:
+            pl.DataFrame: The input ``prices`` frame (including its ``date``
+                column) with each asset column replaced by its per-timestamp
+                cash position. Warmup rows are ``NaN``.
+
+        Example:
+            >>> import polars as pl
+            >>> from tinycta.config import Config
+            >>> from tinycta.engine import Engine
+            >>> prices = pl.DataFrame({"date": [1, 2, 3], "A": [100.0, 101.0, 102.0]})
+            >>> mu = pl.DataFrame({"date": [1, 2, 3], "A": [0.0, 0.1, 0.2]})
+            >>> engine = Engine(prices=prices, mu=mu, cfg=Config(vola=2, corr=2, clip=4.2, shrink=0.5))
+            >>> positions = engine.cash_position
+        """
         cor = self.cor
         assets = self.assets
 

--- a/tests/property/test_properties.py
+++ b/tests/property/test_properties.py
@@ -5,20 +5,33 @@ Tests mathematical invariants for linalg and signal modules.
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
+import polars as pl
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 
+from tinycta.ewma import ma_cross
 from tinycta.linalg import a_norm, inv_a_norm, solve, valid
+from tinycta.osc import osc
 from tinycta.signal import shrink2id
+from tinycta.util import adj_log_prices, vol_adj
 
 # Strategy for positive-definite diagonal matrices (safe for norm/solve tests)
 _pos_diag = arrays(
     dtype=np.float64,
     shape=st.integers(min_value=1, max_value=8),
     elements=st.floats(min_value=0.1, max_value=1e3, allow_nan=False, allow_infinity=False),
+)
+
+# Strategy for strictly-positive finite price series (safe for log/EWMA tests).
+_prices = st.lists(
+    st.floats(min_value=1.0, max_value=1e4, allow_nan=False, allow_infinity=False),
+    min_size=5,
+    max_size=60,
 )
 
 
@@ -115,3 +128,47 @@ def test_shrink2id_lamb_one_preserves_matrix(n: int) -> None:
     mat = rng.standard_normal((n, n))
     result = shrink2id(matrix=mat, lamb=1.0)
     np.testing.assert_array_equal(result, mat)
+
+
+@pytest.mark.property
+@given(prices=_prices)
+@settings(max_examples=50)
+def test_ma_cross_is_sign_valued(prices: list[float]) -> None:
+    """ma_cross only ever emits -1, 0, or +1 (the sign of an EWM difference)."""
+    df = pl.DataFrame({"p": prices}).with_columns(ma_cross(pl.col("p"), fast=2, slow=6).alias("s"))
+    values = [v for v in df["s"].to_list() if v is not None]
+    assert all(v in (-1.0, 0.0, 1.0) for v in values)
+
+
+@pytest.mark.property
+@given(
+    prices=_prices,
+    clip=st.floats(min_value=0.5, max_value=10.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_vol_adj_respects_clip_bound(prices: list[float], clip: float) -> None:
+    """Every finite vol_adj value lies within the symmetric clip bound."""
+    df = pl.DataFrame({"p": prices}).with_columns(vol_adj(pl.col("p"), vola=5, clip=clip).alias("v"))
+    finite = [v for v in df["v"].to_list() if v is not None and math.isfinite(v)]
+    assert all(abs(v) <= clip + 1e-9 for v in finite)
+
+
+@pytest.mark.property
+@given(prices=_prices)
+@settings(max_examples=50)
+def test_adj_log_prices_integrates_vol_adj(prices: list[float]) -> None:
+    """adj_log_prices is the cumulative sum of vol_adj (its first difference recovers vol_adj)."""
+    df = pl.DataFrame({"p": prices})
+    va = df.with_columns(vol_adj(pl.col("p"), vola=5, clip=4.2).alias("x"))["x"]
+    al = df.with_columns(adj_log_prices(pl.col("p"), vola=5, clip=4.2).alias("y"))["y"]
+    np.testing.assert_allclose(al.to_numpy(), va.cum_sum().to_numpy(), rtol=1e-9, equal_nan=True)
+
+
+@pytest.mark.property
+@given(prices=_prices)
+@settings(max_examples=50)
+def test_osc_is_finite(prices: list[float]) -> None:
+    """Osc produces only finite values for finite, strictly-positive price series."""
+    df = pl.DataFrame({"p": prices}).with_columns(osc(pl.col("p"), fast=2, slow=6).alias("o"))
+    values = df["o"].to_list()
+    assert all(v is not None and math.isfinite(v) for v in values)

--- a/uv.lock
+++ b/uv.lock
@@ -1637,10 +1637,20 @@ hyper = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jquantstats" },
+    { name = "loguru" },
     { name = "marimo" },
+    { name = "optuna" },
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "pre-commit" },
+    { name = "pyyaml" },
+]
+hyper = [
+    { name = "jquantstats" },
+    { name = "loguru" },
+    { name = "optuna" },
+    { name = "pyyaml" },
 ]
 lint = [
     { name = "pre-commit" },
@@ -1671,10 +1681,20 @@ provides-extras = ["hyper"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "jquantstats", specifier = ">=0.8.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "marimo", specifier = "==0.23.9" },
+    { name = "optuna", specifier = ">=4.8.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pandas-stubs", specifier = ">=2.2" },
     { name = "pre-commit", specifier = "==4.6.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+]
+hyper = [
+    { name = "jquantstats", specifier = ">=0.8.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "optuna", specifier = ">=4.8.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
 ]
 lint = [{ name = "pre-commit", specifier = "==4.6.0" }]
 test = [

--- a/uv.lock
+++ b/uv.lock
@@ -1622,12 +1622,16 @@ version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "cvx-linalg" },
-    { name = "jquantstats" },
-    { name = "loguru" },
     { name = "numpy" },
-    { name = "optuna" },
     { name = "polars" },
     { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+hyper = [
+    { name = "jquantstats" },
+    { name = "loguru" },
+    { name = "optuna" },
     { name = "pyyaml" },
 ]
 
@@ -1655,14 +1659,15 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "cvx-linalg", specifier = ">=0.5.1" },
-    { name = "jquantstats", specifier = ">=0.8.0" },
-    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "jquantstats", marker = "extra == 'hyper'", specifier = ">=0.8.0" },
+    { name = "loguru", marker = "extra == 'hyper'", specifier = ">=0.7.3" },
     { name = "numpy", specifier = ">=2.0.0" },
-    { name = "optuna", specifier = ">=4.8.0" },
+    { name = "optuna", marker = "extra == 'hyper'", specifier = ">=4.8.0" },
     { name = "polars", specifier = ">=1.21.0" },
     { name = "pydantic", specifier = ">=2.13.3" },
-    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "pyyaml", marker = "extra == 'hyper'", specifier = ">=6.0.3" },
 ]
+provides-extras = ["hyper"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes the three **P2** sub-issues under #759.

## Changes
- **#765** — Move the hyper-only dependency stack (`optuna`, `jquantstats`, `loguru`, `pyyaml`) into a `hyper` optional extra. The core install is now just `numpy`, `polars`, `pydantic`, `cvx-linalg`. Install the optimisation layer with `pip install "tinycta[hyper]"`.
  - Verified all four are imported **only** under `src/tinycta/hyper/`.
  - `make install` uses `uv sync --all-extras --all-groups`, so dev/CI environments still install the extra and tests are unaffected.
  - README gains an install note for the extra.
- **#766** — Documented the `Engine.cash_position` algorithm: the forward walk (mask → shrink correlation → solve/normalise → profit-variance & volatility scaling), the return shape, and a worked `Engine` example.
- **#767** — Added Hypothesis property tests for the Polars signal functions:
  - `ma_cross` only emits −1/0/+1,
  - `vol_adj` respects the symmetric clip bound,
  - `adj_log_prices` is the cumulative sum of `vol_adj`,
  - `osc` stays finite for finite, strictly-positive prices.

## Verification
- `pytest tests/` → **88 passed** (84 → 88), **100% coverage** maintained.
- `deptry src/tinycta` → no dependency issues with the reorg.
- validate-pyproject, uv-lock, ruff, interrogate, markdownlint hooks all pass.

## Note
`CLAUDE.md`'s dependency list is rewritten in #763 (PR #769). This PR intentionally leaves `CLAUDE.md` untouched to avoid a merge conflict; once both land, the hyper deps there should be shown under the new optional extra (trivial follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)