### PR TITLE
docs: complete API reference for all public modules

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,0 +1,5 @@
+# Config
+
+Frozen Pydantic configuration model for the Basanos engine.
+
+::: tinycta.config

--- a/docs/api/engine.md
+++ b/docs/api/engine.md
@@ -1,0 +1,5 @@
+# Engine
+
+Correlation-aware risk/cash position optimizer (the "Basanos" engine).
+
+::: tinycta.engine

--- a/docs/api/ewma.md
+++ b/docs/api/ewma.md
@@ -1,0 +1,5 @@
+# EWMA
+
+Fast-vs-slow EWM moving-average crossover signal.
+
+::: tinycta.ewma

--- a/docs/api/hyper.md
+++ b/docs/api/hyper.md
@@ -1,0 +1,11 @@
+# Hyperparameter Optimisation
+
+Optuna-based hyperparameter-optimisation layer (`tinycta.hyper`).
+
+Installed via the optional `hyper` extra:
+
+```bash
+pip install "tinycta[hyper]"
+```
+
+::: tinycta.hyper

--- a/docs/api/osc.md
+++ b/docs/api/osc.md
@@ -1,0 +1,5 @@
+# Oscillator
+
+Analytically scaled EWMA-difference oscillator for trend-following signals.
+
+::: tinycta.osc

--- a/docs/api/util.md
+++ b/docs/api/util.md
@@ -1,0 +1,5 @@
+# Utilities
+
+Volatility-adjusted log returns and adjusted log-price helpers.
+
+::: tinycta.util

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,14 @@ docs_dir: docs
 nav:
   - Home: index.md
   - API Reference:
+      - Oscillator: api/osc.md
+      - EWMA: api/ewma.md
+      - Utilities: api/util.md
       - Signal: api/signal.md
       - Linear Algebra: api/linalg.md
+      - Config: api/config.md
+      - Engine: api/engine.md
+      - Hyperparameter Optimisation: api/hyper.md
   - Development:
       - Tests: development/TESTS.md
   - CI/CD:


### PR DESCRIPTION
Closes #771.

`docs/api/` previously covered only `linalg` and `signal`, leaving the headline features undocumented.

### Change
- Add mkdocstrings API pages: `osc`, `ewma`, `util`, `config`, `engine`, and the `hyper` package
- Wire all six into the `mkdocs.yml` API Reference nav

### Verification
`mkdocs build --strict` — all six new pages resolve with **no missing-reference warnings**, and each renders its public symbols (`osc`, `ma_cross`, `vol_adj`/`adj_log_prices`, `Config`, `Engine.cash_position`, `Study`/`optimize`/`get_config`/`ExperimentConfig`).

> The strict build still aborts on two **pre-existing** nav entries (`reports/html-coverage/index.html`, `reports/html-report/report.html`) that are generated only in CI and absent from a local build — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
