### PR TITLE
test: replace brittle magic-float assertion in test_signal

### DIFF
--- a/tests/test_tiny_cta/test_signal.py
+++ b/tests/test_tiny_cta/test_signal.py
@@ -9,13 +9,28 @@ import pytest
 from tinycta.signal import moving_absolute_deviation, shrink2id
 
 
-def test_moving_absolute_deviation(prices: pl.DataFrame) -> None:
-    """Test moving_absolute_deviation returns non-negative values."""
+def test_moving_absolute_deviation_non_negative(prices: pl.DataFrame) -> None:
+    """moving_absolute_deviation yields non-negative dispersion for every asset."""
     asset_cols = [c for c in prices.columns if c != "date"]
     mad = prices.with_columns([moving_absolute_deviation(pl.col(c)).alias(c) for c in asset_cols])
     mad_assets = mad.select(asset_cols).drop_nulls()
     assert mad_assets.select(pl.all() >= 0).select(pl.all_horizontal(pl.all())).to_series().all()
-    assert mad.select(pl.col("-9186993121995610806").std()).item() == pytest.approx(0.000859190064724947, rel=1e-3)
+
+
+def test_moving_absolute_deviation_recovers_known_volatility() -> None:
+    """The 1/0.6745 scaling makes MAD a consistent estimator of std under normality.
+
+    Feeding a series whose log returns are i.i.d. normal with a known sigma, the
+    rolling MAD should recover that sigma (rather than matching a fixture-specific
+    magic constant).
+    """
+    rng = np.random.default_rng(0)
+    n, sigma, com = 4000, 0.02, 250
+    prices = 100.0 * np.exp(np.cumsum(rng.normal(0.0, sigma, size=n)))
+    df = pl.DataFrame({"p": prices})
+    mad = df.with_columns(moving_absolute_deviation(pl.col("p"), com=com).alias("mad"))
+    estimate = mad.select(pl.col("mad").median()).item()
+    assert estimate == pytest.approx(sigma, rel=0.1)
 
 
 def test_shrink2id() -> None:


### PR DESCRIPTION
Closes #776.

`test_moving_absolute_deviation` pinned the std of the MAD column to a fixture-specific magic constant (`0.000859190064724947`) on a hashed column name — brittle (breaks if the fixture changes) and opaque (the number means nothing).

### Change
Replaced with two structural tests:
- **non-negativity** of the dispersion estimate across the fixture's assets
- **volatility recovery** — since the `1/0.6745` scaling makes MAD a consistent estimator of std under normality, feeding i.i.d. normal log returns with `sigma=0.02` should recover `~sigma`. Deterministic seed, `rel=0.1` (empirically the error stays <5% across seeds, so 10% is non-flaky).

### Verification
`pytest tests/test_tiny_cta/test_signal.py` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined moving absolute deviation test suite with improved validation of volatility calculations and calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->