### PR TITLE
chore: add project ruff lint rules and satisfy them

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,59 @@
+# Project-level Ruff overrides layered on top of the rhiza-managed `ruff.toml`.
+#
+# `ruff.toml` is template-managed by the Rhiza framework and is overwritten on
+# sync, so project-specific rule choices live here instead. Ruff discovers
+# `.ruff.toml` ahead of `ruff.toml`, and `extend` pulls in the managed base so
+# both layers apply together.
+extend = "ruff.toml"
+
+[lint]
+# Additional rule sets beyond the rhiza base (see issue #778).
+extend-select = [
+    "ANN",  # flake8-annotations - Type annotation checks
+    "ARG",  # flake8-unused-arguments - Unused arguments
+    "PIE",  # flake8-pie - Miscellaneous lints
+    "PL",   # Pylint rules
+    "RET",  # flake8-return - Return statement checks
+    "TID",  # flake8-tidy-imports - Import tidying
+]
+
+# NOTE: ruff *replaces* (does not merge) the `per-file-ignores` table across an
+# `extend` chain, so the rhiza-base entries below are reproduced verbatim and
+# the new-rule relaxations for tests are appended to them.
+[lint.per-file-ignores]
+# Test files - allow assert statements and subprocess calls for testing, and
+# relax the newly-enabled annotation / argument / style rules that add noise
+# without value in tests.
+"**/tests/**/*.py" = [
+    "S101",     # Allow assert statements in tests
+    "S603",     # Allow subprocess calls without shell=False check
+    "S607",     # Allow starting processes with partial paths in tests
+    "PLW1510",  # Allow subprocess without explicit check parameter
+    "ANN",      # Test functions need not be annotated
+    "ARG",      # Unused args are common in fixtures / placeholder callbacks
+    "PLR2004",  # Allow magic values in test comparisons
+    "PLC0206",  # Allow dict index without .items()
+    "PLC0415",  # Allow imports outside top-level in tests
+]
+"tests/**/*.py" = [
+    "ERA001",   # Allow commented out code in project tests
+    "PLR2004",  # Allow magic values in project tests
+    "RUF002",   # Allow ambiguous unicode in project tests
+    "RUF012",   # Allow mutable class attributes in project tests
+]
+# Marimo notebooks - allow flexible coding patterns for interactive exploration
+"**/notebooks/*.py" = [
+    "D100",    # No module docstring - marimo requires `import marimo` as the first statement
+    "N803",    # Allow non-lowercase variable names in notebooks
+    "S101",    # Allow assert statements in notebooks
+    "PLC0415", # Allow imports not at top-level in notebooks
+    "B018",    # Allow useless expressions in notebooks
+    "RUF001",  # Allow ambiguous unicode in notebooks
+    "RUF002",  # Allow ambiguous unicode in notebooks
+]
+# Internal utility scripts - specific exceptions for internal tooling
+".rhiza/utils/*.py" = [
+    "PLW2901",  # Allow loop variable overwriting in utility scripts
+    "TRY003",   # Allow long exception messages in utility scripts
+    "PLW1510",  # subprocess.run guards returncode explicitly (check=False implied)
+]

--- a/src/tinycta/engine.py
+++ b/src/tinycta/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Hashable
 
 import numpy as np
 import polars as pl
@@ -14,15 +15,16 @@ from .linalg import solve as _solve
 from .signal import shrink2id as _shrink2id
 from .util import vol_adj as _vol_adj
 
+# Arbitrary epsilon floor for the correlation-norm denominator: any nearby
+# threshold value or a ``<`` vs ``<=`` boundary behaves identically for
+# realistic denominators, so this comparison is intentionally excluded from
+# mutation.
+_DENOM_EPSILON = 1e-12
+
 
 def _denominator_is_degenerate(denom: float) -> bool:
-    """Return True when the correlation-norm denominator is effectively zero.
-
-    ``1e-12`` is an arbitrary epsilon floor: any nearby threshold value or a
-    ``<`` vs ``<=`` boundary behaves identically for realistic denominators, so
-    this comparison is intentionally excluded from mutation.
-    """
-    return denom <= 1e-12  # pragma: no mutate
+    """Return True when the correlation-norm denominator is effectively zero."""
+    return denom <= _DENOM_EPSILON  # pragma: no mutate
 
 
 def _risk_position(corr: np.ndarray, mu_row: np.ndarray, mask: np.ndarray, shrink: float) -> np.ndarray:
@@ -127,8 +129,32 @@ class Engine:
         )
 
     @property
-    def cor(self) -> dict[object, np.ndarray]:
-        """Per-timestamp EWMA correlation matrices, returned as a date-keyed dict."""
+    def cor(self) -> dict[Hashable, np.ndarray]:
+        """Per-timestamp EWMA correlation matrices, keyed by the ``date`` value.
+
+        Each key is the value of the ``date`` column for that timestamp (a
+        ``datetime.date`` in normal use, though any hashable index value such as
+        an integer is accepted), and each value is the square symmetric
+        correlation matrix over :attr:`assets`, in column order.
+
+        The correlation matrix is derived from the EWMA covariance
+        (:func:`~tinycta.ewm_cov.ewm_covariance`) with span ``2 * cfg.corr + 1``
+        and a ``cfg.corr`` warmup.
+
+        Contract:
+
+        - **Warmup.** Timestamps before any asset pair has accumulated
+          ``cfg.corr`` common observations are absent from the dict entirely
+          (the underlying covariance drops all-NaN dates).
+        - **NaN cells.** A cell is ``NaN`` whenever its variance is
+          non-positive (e.g. an asset that has not yet warmed up, or a
+          late-starting asset); the date is still present as long as at least
+          one cell is finite. Downstream, :attr:`cash_position` masks to the
+          currently-tradable assets, so these ``NaN`` cells are not solved.
+
+        Returns:
+            dict[Hashable, np.ndarray]: Date-keyed correlation matrices.
+        """
         cov = _ewm_covariance(
             self.ret_adj,
             assets=self.assets,

--- a/src/tinycta/ewm_cov.py
+++ b/src/tinycta/ewm_cov.py
@@ -1,4 +1,5 @@
 """Exponentially weighted covariance matrix computation."""
 
-from cvx.linalg.ewm_cov import NegativeWarmupError as NegativeWarmupError
-from cvx.linalg.ewm_cov import ewm_covariance as ewm_covariance
+from cvx.linalg.ewm_cov import NegativeWarmupError, ewm_covariance
+
+__all__ = ["NegativeWarmupError", "ewm_covariance"]

--- a/src/tinycta/hyper/_study.py
+++ b/src/tinycta/hyper/_study.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -69,13 +71,13 @@ def _sharpe(portfolio: Portfolio) -> float:
     """Compute Sharpe ratio, raising TrialPruned if the result is NaN or None."""
     result = portfolio.stats.sharpe()
     sharpe = result["returns"] if isinstance(result, dict) else float(result)
-    if sharpe is None or sharpe != sharpe:
+    if sharpe is None or math.isnan(sharpe):
         raise optuna.exceptions.TrialPruned()
     return sharpe
 
 
 def _run_study(
-    objective,
+    objective: Callable[[optuna.Trial], float],
     *,
     n_trials: int = 100,
     seed: int = 42,
@@ -88,7 +90,9 @@ def _run_study(
     return s
 
 
-def _build_objective(suggest_portfolio_fn):
+def _build_objective(
+    suggest_portfolio_fn: Callable[[optuna.Trial], Portfolio],
+) -> Callable[[optuna.Trial], float]:
     """Objective factory: wraps a portfolio-returning function with Sharpe scoring."""
 
     def objective(trial: optuna.Trial) -> float:
@@ -98,7 +102,7 @@ def _build_objective(suggest_portfolio_fn):
     return objective
 
 
-def optimize(suggest_portfolio_fn, n_trials: int = 100, seed: int = 42) -> Study:
+def optimize(suggest_portfolio_fn: Callable[[optuna.Trial], Portfolio], n_trials: int = 100, seed: int = 42) -> Study:
     """Build objective, run study, print and return a frozen Study."""
     s = _run_study(_build_objective(suggest_portfolio_fn), n_trials=n_trials, seed=seed)
     study = Study.from_optuna(s)

--- a/tests/test_tiny_cta/test_hyper_study.py
+++ b/tests/test_tiny_cta/test_hyper_study.py
@@ -8,6 +8,7 @@ import os
 
 import optuna
 import pytest
+from jquantstats import Portfolio
 
 from tinycta.hyper import Study, optimize
 from tinycta.hyper._study import _build_objective, _run_study, _sharpe
@@ -17,6 +18,12 @@ def _dummy_objective(trial) -> float:
     fast = trial.suggest_int("fast", 2, 10)
     slow = trial.suggest_int("slow", fast + 2, 20)
     return float(slow - fast)
+
+
+def _unused_suggest(trial: optuna.Trial) -> Portfolio:
+    """Placeholder suggest-fn for tests that mock `_build_objective` (never invoked)."""
+    msg = "suggest_portfolio_fn should be mocked, not invoked"
+    raise AssertionError(msg)
 
 
 def test_run_study_returns_optuna_study():

--- a/tests/test_tiny_cta/test_hyper_study.py
+++ b/tests/test_tiny_cta/test_hyper_study.py
@@ -138,7 +138,7 @@ def test_optimize_returns_frozen_study(mocker):
     """Optimize wraps the optuna study in a frozen Study and returns it."""
     mocker.patch("tinycta.hyper._study._build_objective", return_value=lambda trial: 1.0)
 
-    result = optimize(lambda trial: None, n_trials=1)
+    result = optimize(_unused_suggest, n_trials=1)
 
     assert isinstance(result, Study)
     assert result.n_completed == 1
@@ -304,7 +304,7 @@ def test_run_study_disables_progress_bar(mocker):
 def test_optimize_default_n_trials_is_100(mocker):
     """Optimize defaults to 100 trials."""
     mocker.patch("tinycta.hyper._study._build_objective", return_value=lambda trial: 1.0)
-    result = optimize(lambda trial: None)
+    result = optimize(_unused_suggest)
     assert result.n_trials == 100
 
 
@@ -314,8 +314,8 @@ def test_optimize_default_seed_is_42(mocker):
         "tinycta.hyper._study._build_objective",
         return_value=lambda trial: float(trial.suggest_int("x", 0, 100)),
     )
-    default = optimize(lambda trial: None, n_trials=12)
-    explicit = optimize(lambda trial: None, n_trials=12, seed=42)
+    default = optimize(_unused_suggest, n_trials=12)
+    explicit = optimize(_unused_suggest, n_trials=12, seed=42)
     seqs_default = [t.params for t in default.optuna_study.trials]
     seqs_explicit = [t.params for t in explicit.optuna_study.trials]
     assert seqs_default == seqs_explicit
@@ -324,6 +324,6 @@ def test_optimize_default_seed_is_42(mocker):
 def test_optimize_prints_the_study(mocker, capsys):
     """Optimize prints the Study summary (not None) before returning."""
     mocker.patch("tinycta.hyper._study._build_objective", return_value=lambda trial: 1.0)
-    optimize(lambda trial: None, n_trials=1)
+    optimize(_unused_suggest, n_trials=1)
     out = capsys.readouterr().out
     assert "=== Best parameters ===" in out


### PR DESCRIPTION
## Summary

Layer project-level Ruff overrides (`.ruff.toml`) enabling the `ANN`, `ARG`, `PIE`, `PL`, `RET`, and `TID` rule sets on top of the rhiza-managed base, then bring the code into compliance.

The base `ruff.toml` is template-managed by Rhiza and overwritten on sync, so project-specific rule choices live in `.ruff.toml` (discovered ahead of `ruff.toml`, with `extend` pulling in the managed base so both layers apply).

## Changes

- **`engine.py`**: hoist the denominator epsilon to a module constant, annotate the `cor` dict with `Hashable` keys, and expand its docstring contract
- **`ewm_cov.py`**: collapse the redundant re-export aliases into `__all__`
- **`hyper/_study.py`**: add type annotations to the study helpers and use `math.isnan` instead of the self-comparison NaN check
- **`test_hyper_study.py`**: add an annotated placeholder suggest-fn

## Test plan

- Pre-commit (ruff, ruff format, bandit, interrogate, ...) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness in hyperparameter optimization by explicitly handling NaN values during trial pruning.

* **Refactor**
  * Added type annotations throughout the API for improved code clarity and type safety.
  * Reorganized imports for better module organization.

* **Documentation**
  * Enhanced docstrings with clearer descriptions of warmup behavior and NaN-cell handling in risk calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->