### PR TITLE
Fix docs book build: install tinycta into mkdocstrings uvx env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,12 @@ LOGO_FILE=.rhiza/assets/rhiza-logo.svg
 GH_AW_ENGINE ?= copilot  # Default AI engine for gh-aw workflows (copilot, claude, or codex)
 MUTATION_SOURCE_FOLDER ?= src/tinycta
 
-# Override template default: include mkdocstrings plugin for API docs
-MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'
+# Override template default: include mkdocstrings plugin for API docs, plus the
+# tinycta package itself (with the optional hyper extra) so mkdocstrings/griffe
+# can import the modules it documents — including tinycta.hyper and tinycta.linalg
+# (which pulls in cvx-linalg). Without this the isolated uvx env lacks the package
+# and the build fails with "ModuleNotFoundError: No module named 'tinycta'".
+MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]' --with-editable '.[hyper]'
 
 # Always include the Rhiza API (template-managed)
 include .rhiza/rhiza.mk


### PR DESCRIPTION
## Problem

The `make book` target runs zensical in an isolated `uvx` environment:

```
uvx --with 'mkdocstrings[python]' 'zensical>=0.0.36' build -f mkdocs.yml
```

That env had zensical + the mkdocstrings plugin, but **not the `tinycta` package or its dependencies**. mkdocstrings/griffe imports each documented module (`::: tinycta.linalg`, etc.) to collect API docs, so the first collection failed:

```
accessing 'tinycta' raises ModuleNotFoundError: No module named 'tinycta'
Python error: PluginError: Could not collect 'tinycta.linalg'
make: *** [.rhiza/make.d/book.mk:52: book] Error 1
```

## Fix

Extend `MKDOCS_EXTRA_PACKAGES` in the repo-owned `Makefile` to install the package itself, with the optional `hyper` extra:

```make
MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]' --with-editable '.[hyper]'
```

`--with-editable '.[hyper]'` makes `tinycta` and all its runtime deps (incl. `cvx-linalg` for `tinycta.linalg`) plus the optional hyper deps (`tinycta.hyper`) importable during the doc build.

## Verification

Built locally — now reports **"No issues found" / "Build finished"** instead of exiting 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and documentation generation configuration to support enhanced setup and packaging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->