### PR TITLE
docs: add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Lightweight Python Package for Commodity Trading Advisor Strategies.
 [![Coverage](https://tschm.github.io/TinyCTA/coverage-badge.svg)](https://tschm.github.io/TinyCTA/reports/html-coverage/index.html)
 [![Downloads](https://static.pepy.tech/personalized-badge/tinycta?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/tinycta)
 [![CodeFactor](https://www.codefactor.io/repository/github/tschm/TinyCTA/badge)](https://www.codefactor.io/repository/github/tschm/TinyCTA)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tschm/TinyCTA/badge)](https://scorecard.dev/viewer/?uri=github.com/tschm/TinyCTA)
 [![Rhiza](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftschm%2FTinyCTA%2Fmain%2F.rhiza%2Ftemplate.yml&query=%24.ref&label=rhiza&color=blue)](https://github.com/jebel-quant/rhiza)
 
 ---


### PR DESCRIPTION
Adds the OpenSSF Scorecard badge to the README — the last remaining acceptance item for #782.

The other parts of #782 are already in place on `main`:
- **SBOM (CycloneDX)** generated on release via `cyclonedx-py` and attached to releases with a Sigstore attestation (`rhiza_release.yml`).
- **OpenSSF Scorecard workflow** (`rhiza_scorecard.yml`).

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)