### PR TITLE
refactor(engine): accurate cor key typing + guarded divide (#774, #803)

### DIFF
--- a/src/tinycta/engine.py
+++ b/src/tinycta/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Hashable
 
 import numpy as np
 import polars as pl
@@ -127,8 +128,22 @@ class Engine:
         )
 
     @property
-    def cor(self) -> dict[object, np.ndarray]:
-        """Per-timestamp EWMA correlation matrices, returned as a date-keyed dict."""
+    def cor(self) -> dict[Hashable, np.ndarray]:
+        """Per-timestamp EWMA correlation matrices, keyed by index value.
+
+        Each key is a value of the ``date`` column (a ``datetime.date`` in normal
+        use, but any hashable index value such as an integer is supported, hence
+        the ``Hashable`` key type). Each value is the EWMA covariance matrix at
+        that timestamp normalised to a correlation matrix (unit diagonal).
+
+        Contract:
+            - **Warmup:** the first ``cfg.corr`` timestamps are omitted — a key
+              exists only once at least one matrix cell is finite (see
+              :func:`~tinycta.ewm_cov.ewm_covariance`).
+            - **NaN cells:** a cell is ``NaN`` while either asset is still in its
+              own warmup, and a zero-variance asset (``outer == 0``) yields ``NaN``
+              correlations rather than a divide-by-zero.
+        """
         cov = _ewm_covariance(
             self.ret_adj,
             assets=self.assets,
@@ -136,11 +151,14 @@ class Engine:
             window=2 * self.cfg.corr + 1,
             warmup=self.cfg.corr,
         )
-        result = {}
+        result: dict[Hashable, np.ndarray] = {}
         for k, mat in cov.items():
             std = np.sqrt(np.abs(np.diag(mat)))
             outer = np.outer(std, std)
-            result[k] = np.where(outer > 0, mat / outer, np.nan)
+            # Divide only where the variance product is positive; zero-variance
+            # cells stay NaN. Computing ``mat / outer`` eagerly (before masking)
+            # would divide by zero on those cells and emit a spurious RuntimeWarning.
+            result[k] = np.divide(mat, outer, out=np.full(mat.shape, np.nan), where=outer > 0)
         return result
 
     @property


### PR DESCRIPTION
Addresses the two remaining sub-10 scorecard items, both in `Engine.cor`.

## #774 — strengthen typing & contract

`Engine.cor` was annotated `dict[object, np.ndarray]`. Upstream `ewm_covariance` returns `dict[Hashable, np.ndarray]` and its key is the value of the `date` column — a `datetime.date` in normal use, but any hashable index (e.g. integer dates, as used in the docstring example and several tests) is valid. So the accurate annotation is **`dict[Hashable, np.ndarray]`** rather than `datetime.date` (which would mis-describe the integer-keyed usages). Also documented the warmup / NaN contract on the property.

## #803 — avoid divide-by-zero warning

`result[k] = np.where(outer > 0, mat / outer, np.nan)` evaluated `mat / outer` eagerly for **all** cells before masking, so zero-variance cells emitted spurious `divide by zero`/`invalid value` `RuntimeWarning`s. Switched to `np.divide(mat, outer, out=np.full(mat.shape, np.nan), where=outer > 0)` — identical (NaN-aware) result, computed only where the variance product is positive. The test suite is now warning-free.

## Verification

- `make fmt`, `make typecheck` (`ty` + `mypy --strict`), `make test` — all green.
- **138 passed, 100% coverage, zero warnings** (previously 2 `RuntimeWarning`s).
- Behaviour unchanged: verified `np.divide(...)` equals the old `np.where(...)` output (NaN-aware).

Closes #774
Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)