### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for tinycta

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for tinycta.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs tinycta and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies (numpy, polars, ...) into the
+# build environment so PyInstaller can discover and bundle tinycta into each
+# frozen fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover numpy's C-extension submodules on its own, so
+# the frozen fuzzer crashes at runtime with
+# "No module named 'numpy._core._exceptions'". --collect-all pulls in every
+# numpy submodule, data file and shared library. polars is bundled correctly via
+# the static import graph.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy
+done

--- a/tests/fuzz/fuzz_signal.py
+++ b/tests/fuzz/fuzz_signal.py
@@ -1,0 +1,74 @@
+"""Fuzz the tinycta signal pipeline against arbitrary price series.
+
+The signal functions (``osc``, ``ma_cross``, ``moving_absolute_deviation``,
+``vol_adj``, ``adj_log_prices``) transform a polars price expression, and
+``shrink2id`` shrinks a numpy matrix toward the identity. None should crash with
+an unexpected exception on adversarial prices/parameters — they should compute a
+result (possibly null/NaN) or raise a documented error. This harness exercises
+that contract with coverage-guided input.
+
+Run locally:
+    pip install atheris numpy polars
+    python tests/fuzz/fuzz_signal.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+# Pre-import the native dependencies OUTSIDE the instrumentation block. Atheris's
+# import hook miscompiles parts of polars' Python machinery, so we let it load
+# uninstrumented and instrument only the first-party package under test.
+import numpy as np
+import polars as pl
+
+with atheris.instrument_imports():
+    from tinycta.ewma import ma_cross
+    from tinycta.osc import osc
+    from tinycta.signal import moving_absolute_deviation, shrink2id
+    from tinycta.util import adj_log_prices, vol_adj
+
+_ALLOWED = (ValueError, TypeError, ZeroDivisionError, pl.exceptions.PolarsError)
+
+
+def test_one_input(data: bytes) -> None:
+    """Apply each signal transform to a fuzzed price series and matrix."""
+    fdp = atheris.FuzzedDataProvider(data)
+    n = fdp.ConsumeIntInRange(0, 24)
+    prices = pl.DataFrame({"price": [fdp.ConsumeFloat() for _ in range(n)]})
+
+    fast = fdp.ConsumeIntInRange(0, 8)
+    slow = fdp.ConsumeIntInRange(0, 32)
+    com = fdp.ConsumeIntInRange(1, 16)
+    clip = fdp.ConsumeFloat()
+
+    for build_expr in (
+        lambda: osc(pl.col("price"), fast=fast, slow=slow),
+        lambda: ma_cross(pl.col("price"), fast=fast, slow=slow),
+        lambda: moving_absolute_deviation(pl.col("price"), com=com),
+        lambda: vol_adj(pl.col("price"), vola=com, clip=clip),
+        lambda: adj_log_prices(pl.col("price"), vola=com, clip=clip),
+    ):
+        with contextlib.suppress(_ALLOWED):
+            prices.select(build_expr())
+
+    # Pure-numpy path: shrink a fuzzed square matrix toward the identity.
+    m = fdp.ConsumeIntInRange(0, 6)
+    matrix = np.array([fdp.ConsumeFloat() for _ in range(m * m)], dtype=np.float64).reshape(m, m)
+    with contextlib.suppress(_ALLOWED):
+        shrink2id(matrix, fdp.ConsumeProbability())
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the opt-in **ClusterFuzzLite** fuzzing scaffold so the existing `rhiza_fuzzing.yml` workflow actually runs.

- `.clusterfuzzlite/Dockerfile` — OSS-Fuzz Python base image, SHA-pinned
- `.clusterfuzzlite/build.sh` — installs the package and compiles each `tests/fuzz/fuzz_*.py` harness
- `tests/fuzz/fuzz_signal.py` — fuzzes the signal pipeline (osc/ma_cross/moving_absolute_deviation/vol_adj/adj_log_prices) over polars price series plus `shrink2id()`. Native deps pre-imported outside `instrument_imports()` (atheris corrupts instrumented polars).

`FUZZING_ENABLED` is already set to `true`.

## Test plan
- [x] Build verified locally against the OSS-Fuzz `base-builder-python` image (all tinycta modules + polars bundled)
- [ ] Runtime fuzz loop on CI (cannot run locally: polars' Rust binary SIGILLs under x86-on-arm64 emulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
