### PR TITLE
docs(readme): correct moving_absolute_deviation tag to Polars

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ print(study.best_params, study.best_value)
 
 ### Signal Utilities (`tinycta.signal`)
 
-- `moving_absolute_deviation(price, com=32)` — robust rolling volatility estimate via median absolute deviation (pandas)
+- `moving_absolute_deviation(price, com=32)` — robust rolling volatility estimate via median absolute deviation (Polars)
 - `shrink2id(matrix, lamb=1.0)` — shrink a matrix towards the identity matrix
 
 ### Linear Algebra (`tinycta.linalg`)


### PR DESCRIPTION
Closes #816

## Summary
`README.md` line 168 mislabeled `moving_absolute_deviation` as `(pandas)`. The function is a pure Polars expression (`pl.Expr`, `rolling_median`), consistent with every other signal entry tagged `(Polars)`. Changed the tag from `(pandas)` to `(Polars)`.

## Gates
- `make fmt` (markdownlint + README validation): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)