### PR TITLE
docs(claude): align test instructions with Rhiza command policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,12 @@ make marimo     # Start Marimo notebook server
 
 To run a single test file:
 ```bash
-.venv/bin/python -m pytest tests/test_tiny_cta/test_osc.py
+uv run pytest tests/test_tiny_cta/test_osc.py
 ```
 
 To run a specific test:
 ```bash
-.venv/bin/python -m pytest tests/test_tiny_cta/test_osc.py::test_name -v
+uv run pytest tests/test_tiny_cta/test_osc.py::test_name -v
 ```
 
 ## Project Structure


### PR DESCRIPTION
Closes #817

## Summary
`CLAUDE.md` instructed contributors to run tests via `.venv/bin/python -m pytest ...`, which contradicts the Rhiza command-execution policy (prefer `make`; never invoke `.venv/bin/...` directly). Replaced both snippets with the policy-compliant `uv run pytest ...` form.

## Gates
- `make fmt` (markdownlint): PASS
- `make validate` (rhiza-test + template validation): PASS — 175 tests, 99.68% coverage, validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)