### PR TITLE
refactor(hyper): log Study summary instead of print() in optimize()

### DIFF
--- a/src/tinycta/hyper/_study.py
+++ b/src/tinycta/hyper/_study.py
@@ -107,8 +107,8 @@ def optimize(
     n_trials: int = 100,
     seed: int = 42,
 ) -> Study:
-    """Build objective, run study, print and return a frozen Study."""
+    """Build objective, run study, log the summary and return a frozen Study."""
     s = _run_study(_build_objective(suggest_portfolio_fn), n_trials=n_trials, seed=seed)
     study = Study.from_optuna(s)
-    print(study)
+    logger.info(str(study))
     return study

--- a/tests/test_tiny_cta/test_hyper_study.py
+++ b/tests/test_tiny_cta/test_hyper_study.py
@@ -315,9 +315,15 @@ def test_optimize_default_seed_is_42(mocker):
     assert seqs_default == seqs_explicit
 
 
-def test_optimize_prints_the_study(mocker, capsys):
-    """Optimize prints the Study summary (not None) before returning."""
+def test_optimize_logs_the_study(mocker):
+    """Optimize logs the Study summary (not None) before returning."""
+    from loguru import logger
+
     mocker.patch("tinycta.hyper._study._build_objective", return_value=lambda trial: 1.0)
-    optimize(lambda trial: None, n_trials=1)
-    out = capsys.readouterr().out
-    assert "=== Best parameters ===" in out
+    captured: list[str] = []
+    sink_id = logger.add(captured.append, level="INFO", format="{message}")
+    try:
+        optimize(lambda trial: None, n_trials=1)
+    finally:
+        logger.remove(sink_id)
+    assert any("=== Best parameters ===" in message for message in captured)


### PR DESCRIPTION
Closes #818

## Summary
`optimize()` in `src/tinycta/hyper/_study.py` ended with `print(study)`, an unsuppressable stdout side-effect in a library entry point, inconsistent with the rest of the module which uses `loguru.logger`.

- Replaced `print(study)` with `logger.info(str(study))` (the module already imports and uses `logger`).
- Updated the docstring: "build objective, run study, **log the summary** and return a frozen Study".
- Updated the corresponding test (`test_optimize_prints_the_study` → `test_optimize_logs_the_study`) to assert on a captured loguru sink instead of stdout, matching the existing logger-capture pattern in the file.
- Return value/behaviour otherwise unchanged.

## Gates
- `make fmt`: PASS
- `make test`: PASS — 143 tests, 100% coverage (`_study.py` fully covered)
- `make typecheck`: PASS (ty + mypy strict, no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)