### PR TITLE
docs(readme): point License badge at main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Lightweight Python Package for Commodity Trading Advisor Strategies.
 
 [![PyPI version](https://badge.fury.io/py/tinycta.svg)](https://badge.fury.io/py/tinycta)
-[![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/tschm/tinycta/blob/master/LICENSE)
+[![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/tschm/tinycta/blob/main/LICENSE)
 [![Coverage](https://tschm.github.io/TinyCTA/coverage-badge.svg)](https://tschm.github.io/TinyCTA/reports/html-coverage/index.html)
 [![Downloads](https://static.pepy.tech/personalized-badge/tinycta?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/tinycta)
 [![CodeFactor](https://www.codefactor.io/repository/github/tschm/TinyCTA/badge)](https://www.codefactor.io/repository/github/tschm/TinyCTA)


### PR DESCRIPTION
## Summary
The MIT License badge in `README.md` linked to `https://github.com/tschm/tinycta/blob/master/LICENSE`, but the repository's default branch is `main` and no `master` branch exists. The `master` URL only resolved via a 302 redirect (vs HTTP 200 for `main`), which is fragile. This points the badge at `blob/main/LICENSE`.

## Changes
- `README.md` line 6: `blob/master/LICENSE` → `blob/main/LICENSE`

## Gates
- `make fmt` — PASS (markdownlint + all hooks green)

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the license badge link in the README to point to the current default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->