### PR TITLE
chore: update rhiza to v1.0.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.0.0
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.0.0
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.0.0
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
+sha: 3186f09ecffa95a44148fbae02bc90d9e9dd05e2
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.9
+ref: v1.0.0
 include: []
 exclude: []
 templates:
@@ -107,5 +107,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T13:11:39Z'
+synced_at: '2026-06-29T08:04:43Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.19.9"
+ref: "v1.0.0"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `ref` to `v1.0.0` in `.rhiza/template.yml` (major bump from `v0.19.9`, confirmed with maintainer)
- Platform profile: `github-project` (unchanged — matches the `github.com` origin)
- Runs `make sync` to apply upstream template changes; the cruft 3-way merge applied **cleanly with no conflicts**
- Sync touched only Rhiza-owned files: 11 `.github/workflows/*.yml` and `.rhiza/template.lock`

## Quality gates

| Gate | Result | Evidence |
|------|--------|----------|
| `make fmt` | ✅ PASS | All pre-commit hooks passed (ruff format/check, markdownlint, actionlint, bandit, secrets) |
| `make typecheck` | ✅ PASS | `ty`: all checks passed; `mypy --strict`: no issues in 16 source files |
| `make docs-coverage` | ✅ PASS | interrogate 100.0% (min 100.0%) |
| `make deptry` | ✅ PASS | No dependency issues found (12 files scanned) |
| `make security` | ✅ PASS | pip-audit: no vulnerabilities; bandit: clean |
| `make validate` | ✅ PASS | template.yml valid; rhiza infra suite 175 passed |
| `make test` | ✅ PASS | 143 passed; total coverage 100.00% (bar 90%) |

## Scorecard

Scope: locally-owned items only (`src/`, `tests/`, `pyproject.toml`, `README.md`, docs, `.rhiza/template.yml`). Rhiza-managed files (`.github/workflows/*`, `Makefile`, `pytest.ini`, `ruff.toml`, `.pre-commit-config.yaml`) are upstream-owned and excluded from marks.

| Subcategory | Score | Justification | To raise |
|-------------|:-----:|---------------|----------|
| Linting & style | 10/10 | ruff format + check pass clean across the tree | — (maxed) |
| Type safety | 10/10 | `ty` clean **and** `mypy --strict` clean over 16 source files | — (maxed) |
| Test pass rate | 10/10 | 143/143 project tests pass; 175/175 rhiza infra tests pass | — (maxed) |
| Test coverage & depth | 10/10 | 100.00% statement+branch coverage on `src/tinycta` (254 stmts, 48 branches, 0 missed); depth includes property (`tests/property`), mutation (`test_engine_mutation`), and fuzz (`tests/fuzz`) suites | — (maxed; already above the 90% bar) |
| Code structure & readability | 10/10 | Clean 3-layer split (signal expressions → linalg re-exports → engine) matching CLAUDE.md; thin, single-purpose modules | — (maxed) |
| Documentation | 10/10 | interrogate docstring coverage 100% over `src/`; CLAUDE.md documents architecture and commands | — (maxed) |
| Dependency & security hygiene | 10/10 | deptry: no missing/unused/misplaced deps; pip-audit: no CVEs; bandit: clean | — (maxed) |
| CI / tooling health | 10/10 | `make validate` confirms template.yml valid; workflows materialize cleanly. CI workflow content is upstream/out-of-scope | — (in-scope config maxed) |

**Overall: 10/10.** Every in-scope quality gate is at its maximum: 100% test and docstring coverage, strict typing clean, no dependency or security findings, and the v1.0.0 template merge applied with zero conflicts.

**Highest-leverage improvement:** None pressing in-scope — the repo is at the ceiling of the automated gates. The most valuable ongoing action is staying current with upstream `jebel-quant/rhiza` releases (this PR does that). Interrogate verifies docstring *presence* but not depth, so the only soft area is periodic human review of docstring usefulness — not worth a tracked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple automation workflows and the repository template to use the latest `v1.0.0` reusable workflow and action references.
  * This keeps benchmark, CI, code scanning, fuzzing, release, sync, weekly, mutation, book, marimo, and scorecard automation aligned on the same newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->