### PR TITLE
Address rhiza-quality findings (#828–#831)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,38 @@ study = optimize(suggest_portfolio, n_trials=100, seed=42)
 print(study.best_params, study.best_value)
 ```
 
+### Experiment setup (`get_config`)
+
+`tinycta.hyper.get_config` bundles the config sections and a configured logger for a notebook
+experiment. It reads a shared `config.yml` and, for an experiment named `name`, an optional
+experiment-specific `config/{name}.yml`; each `data` / `params` / `optuna` section is taken from
+`config.yml` when present, otherwise from the sibling file. All three sections are optional.
+
+```yaml
+# config.yml — every section is optional
+data:
+  output_path: output   # output dir, relative to the notebooks directory (default: "output")
+params:
+  fast: 12              # arbitrary experiment parameters
+optuna:
+  n_trials: 100         # arbitrary Optuna settings
+```
+
+Paths resolve relative to the **notebooks directory** — the parent of `config.yml`, or its
+grandparent when `config.yml` lives inside a `config/` subdirectory. Outputs are written to
+`{notebooks}/{output_path}/{name}/`, and a config-supplied `output_path` is confined to the
+notebooks directory (a traversing or absolute path raises `ValueError`). Set the
+`NOTEBOOK_OUTPUT_FOLDER` environment variable to override the output directory entirely — this
+explicit operator override is trusted and not confined.
+
+```python +RHIZA_SKIP
+from tinycta.hyper import get_config
+
+cfg = get_config("my_experiment")            # reads ./config.yml (+ ./config/my_experiment.yml)
+cfg.logger.info("run starting")              # loguru logger, also writing to output.log
+fast = cfg.params["fast"]                    # config sections as plain dicts
+```
+
 ## 📚 API Reference
 
 ### Signal Processing (`tinycta.osc`, `tinycta.ewma`, `tinycta.util`)
@@ -185,6 +217,8 @@ print(study.best_params, study.best_value)
 
 - `optimize(suggest_portfolio_fn, n_trials=100, seed=42)` — run an Optuna study scored by Sharpe; returns a `Study`
 - `Study` — frozen result wrapper exposing `best_params`, `best_value`, `n_completed`, `n_trials`, and `.plot(output_dir)`
+- `get_config(name, config_path=None)` — load merged `data`/`params`/`optuna` sections and a configured logger; returns an `ExperimentConfig`
+- `ExperimentConfig` — `NamedTuple` bundling `name`, `logger`, and the optional `params`, `optuna` and `data` sections
 
 ## 🛠️ Development
 

--- a/src/tinycta/hyper/_setup.py
+++ b/src/tinycta/hyper/_setup.py
@@ -28,6 +28,64 @@ def _load_yaml(path: Path) -> dict[str, Any]:
         return yaml.safe_load(f) or {}
 
 
+def _resolve_base(config_path: Path) -> Path:
+    """Return the notebooks directory that paths are resolved relative to.
+
+    This is the grandparent of ``config_path`` when it lives inside a ``config/``
+    subdirectory, otherwise its direct parent.
+    """
+    return config_path.parent.parent if config_path.parent.name == "config" else config_path.parent
+
+
+def _merge_sections(
+    cfg: dict[str, Any], sibling: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Merge the shared ``config.yml`` with the experiment-specific sibling.
+
+    Each of the ``data``, ``params`` and ``optuna`` sections is taken from
+    ``cfg`` when present and truthy, else from ``sibling``, else an empty dict.
+
+    Returns:
+        tuple: ``(data, params, optuna)`` section dicts.
+    """
+    data = cfg.get("data") or sibling.get("data") or {}
+    params = cfg.get("params") or sibling.get("params") or {}
+    optuna_cfg = cfg.get("optuna") or sibling.get("optuna") or {}
+    return data, params, optuna_cfg
+
+
+def _output_dir(base: Path, data: dict[str, Any], name: str) -> Path:
+    """Resolve the experiment output directory and create it.
+
+    ``NOTEBOOK_OUTPUT_FOLDER`` is a deliberate operator override and is used
+    verbatim. Otherwise the directory is ``base / output_path / name`` and is
+    confined under ``base`` so an untrusted ``output_path`` (e.g. ``../../etc``
+    or an absolute path) cannot escape the notebooks directory.
+
+    Raises:
+        ValueError: When the config-derived path escapes ``base``.
+    """
+    env_folder = os.environ.get("NOTEBOOK_OUTPUT_FOLDER")
+    if env_folder:
+        output_dir = Path(env_folder)
+    else:
+        folder = data.get("output_path", "output")
+        base_resolved = base.resolve()
+        output_dir = (base_resolved / folder / name).resolve()
+        if not output_dir.is_relative_to(base_resolved):
+            msg = f"output_path {folder!r} escapes the notebooks directory {base_resolved}"
+            raise ValueError(msg)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _ensure_sink(log_path: Path) -> None:
+    """Register a loguru file sink for ``log_path`` once, keyed by its resolved path."""
+    key = str(log_path.resolve())
+    if key not in _FILE_SINKS:
+        _FILE_SINKS[key] = logger.add(log_path)
+
+
 def get_config(name: str, config_path: Path | str | None = None) -> ExperimentConfig:
     """Return logger and config sections for an experiment.
 
@@ -35,30 +93,18 @@ def get_config(name: str, config_path: Path | str | None = None) -> ExperimentCo
     ``config/{name}.yml``.  Paths in the config are resolved relative to the
     notebooks directory (one level above any ``config/`` subdirectory).
     ``NOTEBOOK_OUTPUT_FOLDER`` env var overrides the output directory used for
-    the log file sink.
+    the log file sink; otherwise the config-derived output directory is confined
+    under the notebooks directory.
     """
     config_path = Path(config_path) if config_path else Path.cwd() / "config.yml"
     cfg = _load_yaml(config_path)
-    # Resolve paths relative to the notebooks dir, not the config subdir.
-    base = config_path.parent.parent if config_path.parent.name == "config" else config_path.parent
+    base = _resolve_base(config_path)
     sibling = _load_yaml(base / "config" / f"{name}.yml")
 
-    data = cfg.get("data") or sibling.get("data") or {}
-    params = cfg.get("params") or sibling.get("params") or {}
-    optuna_cfg = cfg.get("optuna") or sibling.get("optuna") or {}
+    data, params, optuna_cfg = _merge_sections(cfg, sibling)
 
-    env_folder = os.environ.get("NOTEBOOK_OUTPUT_FOLDER")
-    if env_folder:
-        output_dir = Path(env_folder)
-    else:
-        folder = data.get("output_path", "output")
-        output_dir = (base / folder / name).resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    log_path = output_dir / "output.log"
-    key = str(log_path.resolve())
-    if key not in _FILE_SINKS:
-        _FILE_SINKS[key] = logger.add(log_path)
+    output_dir = _output_dir(base, data, name)
+    _ensure_sink(output_dir / "output.log")
     logger.info(f"Writing output to: {output_dir}\nCurrent working directory: {os.getcwd()}")
 
     return ExperimentConfig(

--- a/tests/test_tiny_cta/test_engine_mutation.py
+++ b/tests/test_tiny_cta/test_engine_mutation.py
@@ -52,15 +52,26 @@ def _prices_and_mu(n: int = 40, seed: int = 0, with_gap: bool = False):
 # --------------------------------------------------------------------------- #
 # _update_profit_variance
 # --------------------------------------------------------------------------- #
-def test_update_profit_variance_exact_value():
-    """EWMA profit-variance update equals lamb*pv + (1-lamb)*profit**2."""
+def _profit_variance_reference(pv, cash_prev, returns, ret_mask, lamb):
+    """Documented contract: EWMA-decay ``pv`` towards the squared masked profit.
+
+    Realised profit is the previous cash position dotted with the current returns
+    over the masked assets, with NaNs on either side coerced to zero. Independent
+    re-derivation of the public formula so operator/constant mutations diverge.
+    """
+    profit = np.nan_to_num(cash_prev[ret_mask]) @ np.nan_to_num(returns[ret_mask])
+    return lamb * pv + (1 - lamb) * profit**2
+
+
+def test_update_profit_variance_matches_contract():
+    """The update reproduces the documented lamb*pv + (1-lamb)*profit**2 contract."""
     pv, lamb = 0.5, 0.9
     cash_prev = np.array([1.0, 2.0, np.nan])  # NaN must be treated as 0 on the lhs
     returns = np.array([0.1, 0.2, 0.3])
     ret_mask = np.array([True, True, True])
-    # profit = [1, 2, 0] @ [0.1, 0.2, 0.3] = 0.5
-    # result = 0.9 * 0.5 + 0.1 * 0.5**2 = 0.475
-    assert _update_profit_variance(pv, cash_prev, returns, ret_mask, lamb) == pytest.approx(0.475)
+    got = _update_profit_variance(pv, cash_prev, returns, ret_mask, lamb)
+    assert got == pytest.approx(_profit_variance_reference(pv, cash_prev, returns, ret_mask, lamb))
+    assert got != pytest.approx(pv)  # the update genuinely moved the estimate
 
 
 def test_update_profit_variance_nan_returns_treated_as_zero():
@@ -68,9 +79,8 @@ def test_update_profit_variance_nan_returns_treated_as_zero():
     cash_prev = np.array([1.0, 2.0, 3.0])
     returns = np.array([0.1, 0.2, np.nan])
     ret_mask = np.array([True, True, True])
-    # profit = [1,2,3] @ [0.1,0.2,0] = 0.5 ; result = 0*1.0 ... use lamb=0 to isolate profit
-    result = _update_profit_variance(1.0, cash_prev, returns, ret_mask, 0.0)
-    assert result == pytest.approx(0.5**2)
+    got = _update_profit_variance(1.0, cash_prev, returns, ret_mask, 0.0)  # lamb=0 isolates profit
+    assert got == pytest.approx(_profit_variance_reference(1.0, cash_prev, returns, ret_mask, 0.0))
 
 
 def test_update_profit_variance_mask_selects_entries():
@@ -78,8 +88,10 @@ def test_update_profit_variance_mask_selects_entries():
     cash_prev = np.array([1.0, 99.0, 3.0])
     returns = np.array([0.1, 99.0, 0.3])
     ret_mask = np.array([True, False, True])
-    # profit = [1,3] @ [0.1,0.3] = 1.0 ; lamb=0 -> result = profit**2 = 1.0
-    assert _update_profit_variance(1.0, cash_prev, returns, ret_mask, 0.0) == pytest.approx(1.0)
+    got = _update_profit_variance(1.0, cash_prev, returns, ret_mask, 0.0)  # lamb=0 isolates profit
+    assert got == pytest.approx(_profit_variance_reference(1.0, cash_prev, returns, ret_mask, 0.0))
+    # The masked-out (index 1) entry must not leak into the result.
+    assert got != pytest.approx(_profit_variance_reference(1.0, cash_prev, returns, np.array([True, True, True]), 0.0))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_tiny_cta/test_hyper_setup.py
+++ b/tests/test_tiny_cta/test_hyper_setup.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import tinycta.hyper._setup as setup_mod
 from tinycta.hyper._setup import ExperimentConfig, _load_yaml, get_config
 
@@ -88,6 +90,34 @@ class TestGetConfig:
         assert cfg.params == {"fast": 12}
         assert cfg.optuna == {"n_trials": 5}
         assert cfg.data == {"output_path": "out"}
+
+
+class TestOutputPathConfinement:
+    """A config-supplied output_path must stay within the notebooks directory."""
+
+    def test_relative_traversal_output_path_raises(self, tmp_path, monkeypatch):
+        """A ``../`` output_path that escapes the base dir raises ValueError."""
+        monkeypatch.delenv("NOTEBOOK_OUTPUT_FOLDER", raising=False)
+        (tmp_path / "config.yml").write_text("data:\n  output_path: ../../escape\n")
+        with pytest.raises(ValueError, match="escapes the notebooks directory"):
+            get_config("exp_escape", config_path=tmp_path / "config.yml")
+
+    def test_absolute_output_path_raises(self, tmp_path, monkeypatch):
+        """An absolute output_path outside the base dir raises ValueError."""
+        monkeypatch.delenv("NOTEBOOK_OUTPUT_FOLDER", raising=False)
+        outside = tmp_path.parent / "outside_abs"
+        (tmp_path / "config.yml").write_text(f"data:\n  output_path: {outside}\n")
+        with pytest.raises(ValueError, match="escapes the notebooks directory"):
+            get_config("exp_abs", config_path=tmp_path / "config.yml")
+        assert not (outside / "exp_abs").exists()  # nothing was created outside base
+
+    def test_env_override_may_point_outside_base(self, tmp_path, monkeypatch):
+        """The explicit env override is trusted and not confined to the base dir."""
+        env_dir = tmp_path.parent / "trusted_env_out"
+        monkeypatch.setenv("NOTEBOOK_OUTPUT_FOLDER", str(env_dir))
+        (tmp_path / "config.yml").write_text("")
+        get_config("exp_env_outside", config_path=tmp_path / "config.yml")
+        assert env_dir.exists()
 
 
 class TestExperimentConfigDefaults:


### PR DESCRIPTION
Addresses the four below-10 findings from the rhiza-quality scorecard.

## Changes

- **#828 — `get_config` complexity (9→10).** Extracted `_resolve_base`, `_merge_sections`, `_output_dir`, and `_ensure_sink` helpers. `radon cc` now ranks `get_config` **A (CC 2)** (was **C, CC 11**); no C-or-worse block remains in `src/`.
- **#829 — `output_path` confinement (8→10).** `_output_dir` confines a config-supplied `output_path` under the notebooks directory — a traversing (`../../`) or absolute path now raises `ValueError` before any `mkdir`. The explicit `NOTEBOOK_OUTPUT_FOLDER` operator override remains trusted and unconfined. Three tests added in `TestOutputPathConfinement`.
- **#830 — Test-design pinning (9→10).** The `_update_profit_variance` tests now assert against a documented-contract reference oracle (`_profit_variance_reference`) instead of hard-coded intermediate values, matching the reference-oracle pattern already used for `_risk_position` and `cash_position`.
- **#831 — Docs (9→10).** README now documents the `get_config` `config.yml` schema (`data`/`params`/`optuna`), the notebooks-directory path resolution, `output_path` confinement, and the `NOTEBOOK_OUTPUT_FOLDER` override, plus `get_config`/`ExperimentConfig` in the API reference.

## Verification

- `make fmt` ✅  ·  `make typecheck` (ty + mypy --strict) ✅
- `make test` ✅ — 147 passed, **100.00%** coverage
- README validation tests ✅

Closes #828
Closes #829
Closes #830
Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with clearer setup guidance for experiment configs, output paths, and environment variable overrides.
  * Added API reference entries for the new hyperparameter configuration helpers.

* **Bug Fixes**
  * Strengthened output-directory handling so paths can’t accidentally escape the expected notebooks folder unless an explicit override is set.
  * Improved log file registration to avoid duplicate entries and keep behavior more consistent.

* **Tests**
  * Added coverage for output-path confinement and experiment override behavior.
  * Updated variance-related tests to compare against a reference implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->