### PR TITLE
fix(deps): support cvx-linalg 0.9+/1.0 module layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "cvx-linalg>=0.7.0",
+    "cvx-linalg>=0.9.0",
     "numpy>=2.0.0",
     "polars>=1.21.0",
     "pydantic>=2.13.3",

--- a/src/tinycta/ewm_cov.py
+++ b/src/tinycta/ewm_cov.py
@@ -1,4 +1,4 @@
 """Exponentially weighted covariance matrix computation."""
 
-from cvx.linalg.ewm_cov import NegativeWarmupError as NegativeWarmupError
-from cvx.linalg.ewm_cov import ewm_covariance as ewm_covariance
+from cvx.linalg.covariance.ewm_cov import NegativeWarmupError as NegativeWarmupError
+from cvx.linalg.covariance.ewm_cov import ewm_covariance as ewm_covariance

--- a/tests/test_tiny_cta/test_linalg.py
+++ b/tests/test_tiny_cta/test_linalg.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from cvx.linalg.exceptions import DimensionMismatchError, NonSquareMatrixError
+from cvx.linalg import DimensionMismatchError, NonSquareMatrixError
 
 from tinycta.linalg import a_norm, inv_a_norm, solve, valid
 

--- a/uv.lock
+++ b/uv.lock
@@ -264,14 +264,14 @@ toml = [
 
 [[package]]
 name = "cvx-linalg"
-version = "0.8.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/a0/a1c198e4e01bf1eb2e61bdc81943be7fe80aad5c1fdff2504bf209505503/cvx_linalg-0.8.0.tar.gz", hash = "sha256:38533d446b88300c7dd776efee10105fce293e5a51819f9c42be38bbc8352ed8", size = 25520, upload-time = "2026-06-16T14:25:31.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/80/06c3d348fc0665de348888d14f2134c210b0720fc5d0e24b3da41f5052c7/cvx_linalg-1.0.0.tar.gz", hash = "sha256:c3626155679434344bbe1a765db7c16c943f4f424ef1ee34e7b464f32fdb570a", size = 41122, upload-time = "2026-07-07T04:32:50.891Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/1a/13c31e88049fb033d3e858ba94e6d0a5aff812aff4f5857e29105efc18b8/cvx_linalg-0.8.0-py3-none-any.whl", hash = "sha256:8c2fc777037eb26ec30b5dc242ddfc05663a8d78f85e96180acd25a0a9cea61a", size = 28527, upload-time = "2026-06-16T14:25:30.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7f/e8ae0b18c421c53ab7c47e982b2aeda8f80844240b82e7118a5d5192f5c0/cvx_linalg-1.0.0-py3-none-any.whl", hash = "sha256:b59231d1bc7db260986e9527e9c2aa2c2f374259f135b8463353c6bd515eecf9", size = 51349, upload-time = "2026-07-07T04:32:49.601Z" },
 ]
 
 [[package]]
@@ -1664,7 +1664,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cvx-linalg", specifier = ">=0.7.0" },
+    { name = "cvx-linalg", specifier = ">=0.9.0" },
     { name = "jquantstats", marker = "extra == 'hyper'", specifier = ">=0.9.6" },
     { name = "loguru", marker = "extra == 'hyper'", specifier = ">=0.7.3" },
     { name = "numpy", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Problem

The dependabot bump to `cvx-linalg` 0.9.6 (#834) failed CI with:

```
ModuleNotFoundError: No module named 'cvx.linalg.ewm_cov'
ModuleNotFoundError: No module named 'cvx.linalg.exceptions'
```

`cvx-linalg` restructured its package:
- **0.9.0** moved `ewm_covariance` and `NegativeWarmupError` from `cvx.linalg.ewm_cov` → `cvx.linalg.covariance.ewm_cov`.
- The `cvx.linalg.exceptions` submodule was dropped; `DimensionMismatchError` / `NonSquareMatrixError` are re-exported at the `cvx.linalg` package root.

## Fix

- `src/tinycta/ewm_cov.py`: import from `cvx.linalg.covariance.ewm_cov`.
- `tests/test_tiny_cta/test_linalg.py`: import the exceptions from `cvx.linalg` directly.
- Bump the floor to `cvx-linalg>=0.9.0` and relock — resolves to **1.0.0**.

The function signatures are unchanged, so no call sites needed edits.

## Verification

- `147 passed` (full suite) + `3 passed` doctests on `src/tinycta`, all against cvx-linalg 1.0.0.
- `ruff check` clean.

This supersedes the `cvx-linalg` portion of #834 by fixing the code, not just the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a core dependency requirement to a newer supported version.
  * Adjusted internal import paths to stay compatible with the latest library layout.

* **Tests**
  * Refreshed test imports to match the updated public API, with no behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->