### PR TITLE
refactor(engine): extract numeric kernel to raise complexity & architecture scores (#843)

### DIFF
--- a/src/tinycta/_kernel.py
+++ b/src/tinycta/_kernel.py
@@ -1,0 +1,142 @@
+"""Pure-NumPy numeric kernel for the correlation-aware position optimizer.
+
+Every function here operates on NumPy arrays only — no Polars, no :class:`~tinycta.config.Config`
+— so the Polars-facing orchestration in :mod:`tinycta.engine` stays a thin adapter that
+prepares arrays, delegates the timestamp walk to :func:`forward_walk`, and writes the result
+back into a DataFrame.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+
+import numpy as np
+from loguru import logger
+
+from .linalg import inv_a_norm as _inv_a_norm
+from .linalg import solve as _solve
+from .signal import shrink2id as _shrink2id
+
+
+def _denominator_is_degenerate(denom: float) -> bool:
+    """Return True when the correlation-norm denominator is effectively zero.
+
+    ``1e-12`` is an arbitrary epsilon floor: any nearby threshold value or a
+    ``<`` vs ``<=`` boundary behaves identically for realistic denominators, so
+    this comparison is intentionally excluded from mutation.
+    """
+    return denom <= 1e-12  # pragma: no mutate
+
+
+def _risk_position(corr: np.ndarray, mu_row: np.ndarray, mask: np.ndarray, shrink: float) -> np.ndarray:
+    """Solve the shrunk correlation system for one timestamp's tradable assets.
+
+    Shrinks ``corr`` towards the identity by ``shrink`` (via
+    :func:`~tinycta.signal.shrink2id`), restricts it to the masked assets, solves
+    for the expected returns ``mu_row`` and normalises by ``inv_a_norm`` so the raw
+    risk position has unit norm under the correlation metric. Returns zeros when the
+    normaliser is non-finite/degenerate or ``mu_row`` is all-zero.
+
+    Args:
+        corr: Full EWMA correlation matrix for the timestamp.
+        mu_row: Expected returns for every asset at the timestamp (NaNs tolerated).
+        mask: Boolean mask of currently-tradable assets.
+        shrink: Identity-shrinkage weight in ``[0, 1]``.
+
+    Returns:
+        np.ndarray: The normalised risk position over the masked assets.
+    """
+    matrix = _shrink2id(corr, lamb=shrink)[np.ix_(mask, mask)]
+    expected_mu = np.nan_to_num(mu_row[mask])
+    denom = _inv_a_norm(expected_mu, matrix)
+    if denom is None or not np.isfinite(denom) or _denominator_is_degenerate(denom) or np.allclose(expected_mu, 0.0):
+        logger.debug(
+            "Risk position zeroed for {} masked asset(s): degenerate correlation-norm "
+            "denominator (denom={}) or all-zero expected returns.",
+            int(mask.sum()),
+            denom,
+        )
+        return np.zeros_like(expected_mu)
+    return _solve(matrix, expected_mu) / denom
+
+
+def _update_profit_variance(
+    profit_variance: float,
+    cash_pos_prev: np.ndarray,
+    returns_row: np.ndarray,
+    ret_mask: np.ndarray,
+    lamb: float,
+) -> float:
+    """EWMA-update the running profit-variance estimate with one period's P&L.
+
+    Realised profit is the previous cash position dotted with the current returns
+    over the jointly-finite assets; the variance decays towards the new squared
+    profit by ``1 - lamb``.
+
+    Args:
+        profit_variance: Previous running profit-variance estimate.
+        cash_pos_prev: Previous timestamp's cash position (NaNs tolerated).
+        returns_row: Current timestamp's simple returns (NaNs tolerated).
+        ret_mask: Boolean mask of assets finite in both rows.
+        lamb: EWMA decay factor.
+
+    Returns:
+        float: The updated profit-variance estimate.
+    """
+    lhs = np.nan_to_num(cash_pos_prev[ret_mask], nan=0.0)
+    rhs = np.nan_to_num(returns_row[ret_mask], nan=0.0)
+    profit = lhs @ rhs
+    return float(lamb * profit_variance + (1 - lamb) * profit**2)
+
+
+def forward_walk(
+    cor: dict[Hashable, np.ndarray],
+    prices_num: np.ndarray,
+    returns_num: np.ndarray,
+    mu: np.ndarray,
+    vola_np: np.ndarray,
+    risk_pos_np: np.ndarray,
+    cash_pos_np: np.ndarray,
+    row_of: dict[Hashable, int],
+    shrink: float,
+) -> None:
+    """Walk forward through the post-warmup timestamps, filling positions in place.
+
+    Mutates ``risk_pos_np`` and ``cash_pos_np`` row-by-row. At each timestamp the
+    previous period's realised P&L EWMA-updates a running profit-variance estimate
+    (decay ``lamb=0.99``), which scales the freshly-solved risk position before it is
+    divided by per-asset volatility to yield the cash position.
+
+    Args:
+        cor: Per-timestamp correlation matrices, keyed by ``date`` value.
+        prices_num: Asset prices as a ``(rows, assets)`` array (NaNs tolerated).
+        returns_num: Simple returns aligned to ``prices_num``.
+        mu: Expected returns aligned to ``prices_num``.
+        vola_np: Per-asset EWMA volatility aligned to ``prices_num``.
+        risk_pos_np: Output risk-position buffer, mutated in place.
+        cash_pos_np: Output cash-position buffer, mutated in place.
+        row_of: Map from a ``cor`` key back to its row index.
+        shrink: Identity-shrinkage weight in ``[0, 1]`` passed to :func:`_risk_position`.
+    """
+    profit_variance = 1.0
+    lamb = 0.99
+
+    prev_row: int | None = None
+    for t in cor:
+        row = row_of[t]
+        mask = np.isfinite(prices_num[row])
+
+        if prev_row is not None:
+            ret_mask = np.isfinite(returns_num[row]) & mask
+            if ret_mask.any():
+                cash_pos_np[prev_row] = risk_pos_np[prev_row] / vola_np[prev_row]
+                profit_variance = _update_profit_variance(
+                    profit_variance, cash_pos_np[prev_row], returns_num[row], ret_mask, lamb
+                )
+
+        if mask.any():
+            pos = _risk_position(cor[t], mu[row], mask, shrink)
+            risk_pos_np[row, mask] = pos / profit_variance
+            cash_pos_np[row, mask] = risk_pos_np[row, mask] / vola_np[row, mask]
+
+        prev_row = row

--- a/src/tinycta/engine.py
+++ b/src/tinycta/engine.py
@@ -1,4 +1,10 @@
-"""Engine for correlation-aware risk position optimization."""
+"""Engine for correlation-aware risk position optimization.
+
+This module is the Polars-facing orchestration layer: :class:`Engine` validates and holds
+the aligned ``prices``/``mu`` frames, derives the volatility-adjusted returns and per-timestamp
+EWMA correlation matrices, and hands the resulting NumPy arrays to the pure-numeric kernel in
+:mod:`tinycta._kernel` for the forward walk.
+"""
 
 from __future__ import annotations
 
@@ -7,85 +13,11 @@ from collections.abc import Hashable
 
 import numpy as np
 import polars as pl
-from loguru import logger
 
+from ._kernel import forward_walk as _forward_walk
 from .config import Config
 from .ewm_cov import ewm_covariance as _ewm_covariance
-from .linalg import inv_a_norm as _inv_a_norm
-from .linalg import solve as _solve
-from .signal import shrink2id as _shrink2id
 from .util import vol_adj as _vol_adj
-
-
-def _denominator_is_degenerate(denom: float) -> bool:
-    """Return True when the correlation-norm denominator is effectively zero.
-
-    ``1e-12`` is an arbitrary epsilon floor: any nearby threshold value or a
-    ``<`` vs ``<=`` boundary behaves identically for realistic denominators, so
-    this comparison is intentionally excluded from mutation.
-    """
-    return denom <= 1e-12  # pragma: no mutate
-
-
-def _risk_position(corr: np.ndarray, mu_row: np.ndarray, mask: np.ndarray, shrink: float) -> np.ndarray:
-    """Solve the shrunk correlation system for one timestamp's tradable assets.
-
-    Shrinks ``corr`` towards the identity by ``shrink`` (via
-    :func:`~tinycta.signal.shrink2id`), restricts it to the masked assets, solves
-    for the expected returns ``mu_row`` and normalises by ``inv_a_norm`` so the raw
-    risk position has unit norm under the correlation metric. Returns zeros when the
-    normaliser is non-finite/degenerate or ``mu_row`` is all-zero.
-
-    Args:
-        corr: Full EWMA correlation matrix for the timestamp.
-        mu_row: Expected returns for every asset at the timestamp (NaNs tolerated).
-        mask: Boolean mask of currently-tradable assets.
-        shrink: Identity-shrinkage weight in ``[0, 1]``.
-
-    Returns:
-        np.ndarray: The normalised risk position over the masked assets.
-    """
-    matrix = _shrink2id(corr, lamb=shrink)[np.ix_(mask, mask)]
-    expected_mu = np.nan_to_num(mu_row[mask])
-    denom = _inv_a_norm(expected_mu, matrix)
-    if denom is None or not np.isfinite(denom) or _denominator_is_degenerate(denom) or np.allclose(expected_mu, 0.0):
-        logger.debug(
-            "Risk position zeroed for {} masked asset(s): degenerate correlation-norm "
-            "denominator (denom={}) or all-zero expected returns.",
-            int(mask.sum()),
-            denom,
-        )
-        return np.zeros_like(expected_mu)
-    return _solve(matrix, expected_mu) / denom
-
-
-def _update_profit_variance(
-    profit_variance: float,
-    cash_pos_prev: np.ndarray,
-    returns_row: np.ndarray,
-    ret_mask: np.ndarray,
-    lamb: float,
-) -> float:
-    """EWMA-update the running profit-variance estimate with one period's P&L.
-
-    Realised profit is the previous cash position dotted with the current returns
-    over the jointly-finite assets; the variance decays towards the new squared
-    profit by ``1 - lamb``.
-
-    Args:
-        profit_variance: Previous running profit-variance estimate.
-        cash_pos_prev: Previous timestamp's cash position (NaNs tolerated).
-        returns_row: Current timestamp's simple returns (NaNs tolerated).
-        ret_mask: Boolean mask of assets finite in both rows.
-        lamb: EWMA decay factor.
-
-    Returns:
-        float: The updated profit-variance estimate.
-    """
-    lhs = np.nan_to_num(cash_pos_prev[ret_mask], nan=0.0)
-    rhs = np.nan_to_num(returns_row[ret_mask], nan=0.0)
-    profit = lhs @ rhs
-    return float(lamb * profit_variance + (1 - lamb) * profit**2)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -188,6 +120,9 @@ class Engine:
            after volatile P&L, then divide by per-asset EWMA volatility
            (``self.vola``) to convert the risk position into a cash position.
 
+        The per-timestamp walk itself is delegated to
+        :func:`tinycta._kernel.forward_walk`, which operates purely on NumPy arrays.
+
         Returns:
             pl.DataFrame: The input ``prices`` frame (including its ``date``
                 column) with each asset column replaced by its per-timestamp
@@ -220,57 +155,6 @@ class Engine:
         # ``corr`` rows — otherwise the most recent dates never receive a position.
         row_of = {date: idx for idx, date in enumerate(self.prices["date"].to_list())}
 
-        self._forward_walk(cor, prices_num, returns_num, mu, vola_np, risk_pos_np, cash_pos_np, row_of)
+        _forward_walk(cor, prices_num, returns_num, mu, vola_np, risk_pos_np, cash_pos_np, row_of, self.cfg.shrink)
 
         return self.prices.with_columns([(pl.lit(cash_pos_np[:, i]).alias(asset)) for i, asset in enumerate(assets)])
-
-    def _forward_walk(
-        self,
-        cor: dict[Hashable, np.ndarray],
-        prices_num: np.ndarray,
-        returns_num: np.ndarray,
-        mu: np.ndarray,
-        vola_np: np.ndarray,
-        risk_pos_np: np.ndarray,
-        cash_pos_np: np.ndarray,
-        row_of: dict[Hashable, int],
-    ) -> None:
-        """Walk forward through the post-warmup timestamps, filling positions in place.
-
-        Mutates ``risk_pos_np`` and ``cash_pos_np`` row-by-row. At each timestamp the
-        previous period's realised P&L EWMA-updates a running profit-variance estimate
-        (decay ``lamb=0.99``), which scales the freshly-solved risk position before it is
-        divided by per-asset volatility to yield the cash position.
-
-        Args:
-            cor: Per-timestamp correlation matrices, keyed by ``date`` value.
-            prices_num: Asset prices as a ``(rows, assets)`` array (NaNs tolerated).
-            returns_num: Simple returns aligned to ``prices_num``.
-            mu: Expected returns aligned to ``prices_num``.
-            vola_np: Per-asset EWMA volatility aligned to ``prices_num``.
-            risk_pos_np: Output risk-position buffer, mutated in place.
-            cash_pos_np: Output cash-position buffer, mutated in place.
-            row_of: Map from a ``cor`` key back to its row index.
-        """
-        profit_variance = 1.0
-        lamb = 0.99
-
-        prev_row: int | None = None
-        for t in cor:
-            row = row_of[t]
-            mask = np.isfinite(prices_num[row])
-
-            if prev_row is not None:
-                ret_mask = np.isfinite(returns_num[row]) & mask
-                if ret_mask.any():
-                    cash_pos_np[prev_row] = risk_pos_np[prev_row] / vola_np[prev_row]
-                    profit_variance = _update_profit_variance(
-                        profit_variance, cash_pos_np[prev_row], returns_num[row], ret_mask, lamb
-                    )
-
-            if mask.any():
-                pos = _risk_position(cor[t], mu[row], mask, self.cfg.shrink)
-                risk_pos_np[row, mask] = pos / profit_variance
-                cash_pos_np[row, mask] = risk_pos_np[row, mask] / vola_np[row, mask]
-
-            prev_row = row

--- a/tests/test_tiny_cta/test_engine.py
+++ b/tests/test_tiny_cta/test_engine.py
@@ -8,8 +8,9 @@ import numpy as np
 import polars as pl
 import pytest
 
+from tinycta._kernel import _risk_position
 from tinycta.config import Config
-from tinycta.engine import Engine, _risk_position
+from tinycta.engine import Engine
 
 
 def _synthetic_prices(n_days: int = 500, assets: list[str] | None = None) -> pl.DataFrame:

--- a/tests/test_tiny_cta/test_engine_mutation.py
+++ b/tests/test_tiny_cta/test_engine_mutation.py
@@ -17,8 +17,9 @@ import polars as pl
 import polars.testing as pt
 import pytest
 
+from tinycta._kernel import _risk_position, _update_profit_variance
 from tinycta.config import Config
-from tinycta.engine import Engine, _risk_position, _update_profit_variance
+from tinycta.engine import Engine
 from tinycta.ewm_cov import ewm_covariance
 from tinycta.linalg import inv_a_norm, solve
 from tinycta.signal import shrink2id


### PR DESCRIPTION
## Summary
Closes #843. Decomposes `src/tinycta/engine.py` into two focused modules so the densest source file is no longer a size/maintainability outlier:

- **`src/tinycta/engine.py`** — thin Polars-facing orchestration: the `Engine` dataclass (validation, `assets`/`ret_adj`/`vola`/`cor` properties, `cash_position`). It prepares NumPy arrays and delegates the timestamp walk.
- **`src/tinycta/_kernel.py`** (new) — pure-NumPy numeric kernel: `_risk_position`, `_update_profit_variance`, `_denominator_is_degenerate`, and `forward_walk` (previously the `Engine._forward_walk` method, now a free function taking `shrink` as a parameter). No Polars/Config dependency.

No behaviour change — pure extraction. The two engine test modules now import the kernel functions from `tinycta._kernel`.

## Before → After

| Metric | Before | After |
|---|---|---|
| `engine.py` LOC | 277 | **160** |
| `engine.py` MI | A (60.8) | **A (69.1)** |
| `_kernel.py` MI | — | **A (72.7)** |
| Largest `src/` module | 277 | **160** |
| Coverage (line+branch) | 100% | **100%** |

**Done when** (acceptance criteria from #843): `engine.py` MI ≥ A with no module > ~200 LOC and coverage stays 100% — all met.

## Gates
`fmt` ✅ · `typecheck` ✅ (ty + mypy --strict, 13 files) · `test` ✅ (148 passed, 100% line+branch coverage; `_kernel.py` and `engine.py` both 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)