### PR TITLE
refactor(osc): simplify _validate_windows to CC grade A

### DIFF
--- a/src/tinycta/osc.py
+++ b/src/tinycta/osc.py
@@ -22,21 +22,19 @@ def _validate_windows(fast: int, slow: int) -> None:
         TypeError: If ``fast`` or ``slow`` are not integers.
         ValueError: If ``fast <= 1``, ``slow <= 1``, or ``fast >= slow``.
     """
-    if not isinstance(fast, int):
-        msg = "fast must be an integer"
-        raise TypeError(msg)
-    if not isinstance(slow, int):
-        msg = "slow must be an integer"
-        raise TypeError(msg)
-    if fast <= 1:
-        msg = "fast must be greater than 1"
-        raise ValueError(msg)
-    if slow <= 1:
-        msg = "slow must be greater than 1"
-        raise ValueError(msg)
-    if fast >= slow:
-        msg = "fast must be less than slow"
-        raise ValueError(msg)
+    for value, name in ((fast, "fast"), (slow, "slow")):
+        if not isinstance(value, int):
+            msg = f"{name} must be an integer"
+            raise TypeError(msg)
+
+    value_checks = (
+        (fast <= 1, "fast must be greater than 1"),
+        (slow <= 1, "slow must be greater than 1"),
+        (fast >= slow, "fast must be less than slow"),
+    )
+    for failed, msg in value_checks:
+        if failed:
+            raise ValueError(msg)
 
 
 def osc(x: pl.Expr, fast: int, slow: int, min_samples: int = 1) -> pl.Expr:


### PR DESCRIPTION
## Summary
- Refactors `_validate_windows` in `src/tinycta/osc.py` to drive the fast/slow window validation from tables (one type-check loop, one value-check loop) instead of five sequential `if` statements.
- Lowers cyclomatic complexity from **B(6)** to **A(5)** — the module's only above-A block, and the sole below-10 subcategory in the `/rhiza:quality` scorecard.

## Behavior preserved
Check ordering and the exact exception types and messages are unchanged:
- `fast` type-checked before `slow` (both `TypeError`, "fast/slow must be an integer")
- value checks fire in order `fast <= 1` → `slow <= 1` → `fast >= slow` (all `ValueError` with the same messages)

The existing `test_osc.py` cases pin every message and boundary exactly and remain green.

## Verification
- `radon cc src/tinycta/osc.py` → `_validate_windows - A (5)`
- `make fmt` — all hooks pass
- `make test` — 148 passed, coverage 100.0% (`osc.py` 100%)

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined validation for configuration values while preserving existing behavior and error messages.
  * No user-facing functionality or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->