### PR TITLE
chore: normalize .rhiza/template.yml

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -5,4 +5,4 @@ profiles:
   - github-project
 
 templates:
-    - legal
+  - legal


### PR DESCRIPTION
Normalize `.rhiza/template.yml` formatting: fix `templates:` list indentation (4→2 spaces) to match the other repos.

`make sync` reports no file changes (template already up to date).