### PR TITLE
chore: drop rhiza-tools tooling from make targets

### DIFF
--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -5,7 +5,7 @@
 LICENSE_FAIL_ON ?= GPL;LGPL;AGPL
 
 # Declare phony targets (they don't produce files)
-.PHONY: all deptry fmt license todos suppression-audit semgrep
+.PHONY: all deptry fmt license todos semgrep
 
 ##@ Quality and Formatting
 all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run all CI targets locally
@@ -51,10 +51,6 @@ todos: ## search and report all TODO/FIXME/HACK comments in the codebase
 		awk -F: '{ printf "${YELLOW}%s${RESET}:${GREEN}%s${RESET}: %s\n", $$1, $$2, substr($$0, index($$0,$$3)) }' || \
 		printf "${GREEN}[SUCCESS] No TODO/FIXME/HACK comments found!${RESET}\n"
 	@printf "\n${BLUE}[INFO] Search complete.${RESET}\n"
-
-suppression-audit: install-uv ## scan codebase for inline suppressions and report (grade, detail, histogram)
-	@printf "${BLUE}[INFO] Running suppression audit...${RESET}\n"
-	@${UVX_BIN} "rhiza-tools>=0.8.1" suppression-audit
 
 semgrep: install ## run Semgrep static analysis
 	@printf "${BLUE}[INFO] Running Semgrep...${RESET}\n"

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -112,16 +112,9 @@ typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both
 	    ;; \
 	esac
 
-# Extra flags forwarded to pip-audit (e.g. --ignore-vuln CVE-XXXX-YYYY)
-PIP_AUDIT_ARGS ?=
-
 # The 'security' target performs security vulnerability scans.
-# 1. Runs pip-audit via `rhiza-tools pip-audit` (tiered policy): fails on runtime
-#    dep CVEs, warns on tooling (pip/setuptools/wheel).
-# 2. Runs bandit to find common security issues in Python source folders that exist.
-security: install ## run security scans (pip-audit and bandit)
-	@printf "${BLUE}[INFO] Running pip-audit for dependency vulnerabilities...${RESET}\n"
-	@${UVX_BIN} "rhiza-tools>=0.8.1" pip-audit ${PIP_AUDIT_ARGS}
+# Runs bandit to find common security issues in Python source folders that exist.
+security: install ## run security scans (bandit)
 	@bandit_paths=""; \
 	if [ -d "${SOURCE_FOLDER}" ]; then \
 	  bandit_paths="${SOURCE_FOLDER}"; \
@@ -137,7 +130,6 @@ security: install ## run security scans (pip-audit and bandit)
 # 1. Installs benchmarking dependencies (pytest-benchmark, pygal).
 # 2. Executes benchmarks found in the benchmarks/ subfolder.
 # 3. Generates histograms and JSON results.
-# 4. Runs a post-analysis script to process the results.
 benchmark:: install ## run performance benchmarks
 	@if [ -d "${TESTS_FOLDER}/benchmarks" ]; then \
 	  printf "${BLUE}[INFO] Running performance benchmarks...${RESET}\n"; \
@@ -146,7 +138,6 @@ benchmark:: install ## run performance benchmarks
 	  		--benchmark-only \
 			--benchmark-histogram=_tests/benchmarks/histogram \
 			--benchmark-json=_tests/benchmarks/results.json; \
-	  ${UVX_BIN} "rhiza-tools>=0.2.3" analyze-benchmarks --benchmarks-json _tests/benchmarks/results.json --output-html _tests/benchmarks/report.html; \
 	else \
 	  printf "${YELLOW}[WARN] Benchmarks folder not found, skipping benchmarks${RESET}\n"; \
 	fi


### PR DESCRIPTION
Removes rhiza-tools invocations from the `.rhiza` make targets:

- **security** (`test.mk`): drop the `uvx rhiza-tools pip-audit` step — the target now runs bandit only.
- **benchmark** (`test.mk`): drop the `rhiza-tools analyze-benchmarks` HTML-report step (pytest-benchmark still produces histogram + JSON).
- **quality** (`quality.mk`): remove the `suppression-audit` target (`uvx rhiza-tools suppression-audit`) and its `.PHONY` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)