### PR TITLE
chore: add Python 3.14 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "cvx-linalg>=0.9.0",


### PR DESCRIPTION
## Summary
- Add the `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`

The `readme` make target removal originally in this branch is now redundant — upstream `main` already dropped it during a `.rhiza/rhiza.mk` restructure, so that change was resolved out during the rebase.

## Test plan
- pre-commit hooks pass (Python version consistency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)