### PR TITLE
chore: drop redundant lint dependency group

### DIFF
--- a/.rhiza/tests/test_pyproject.py
+++ b/.rhiza/tests/test_pyproject.py
@@ -12,7 +12,6 @@ Validates that pyproject.toml:
 - provides [project.urls] with Homepage and Repository
 - includes at least one Python version classifier
 - declares a [dependency-groups] test group containing pytest
-- declares a [dependency-groups] lint group
 - version matches the latest git tag (vX.Y.Z → X.Y.Z)
 """
 
@@ -191,10 +190,6 @@ class TestDependencyGroups:
         assert any("pytest" in str(dep).lower() for dep in test_deps), (
             "[dependency-groups.test] must list pytest as a dependency"
         )
-
-    def test_lint_group_present(self, dependency_groups: dict) -> None:
-        """A 'lint' dependency group must be declared."""
-        assert "lint" in dependency_groups, "[dependency-groups] must include a 'lint' group"
 
 
 class TestGitTagVersion:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,6 @@ test = [
     "hypothesis>=6.155.3",
     "pytest-benchmark>=5.2.3",
 ]
-lint = [
-    "pre-commit==4.6.1",
-]
 
 [tool.uv]
 # Install both dev tooling and the hyper extra by default so `uv sync` provides

--- a/uv.lock
+++ b/uv.lock
@@ -1696,9 +1696,6 @@ hyper = [
     { name = "optuna" },
     { name = "pyyaml" },
 ]
-lint = [
-    { name = "pre-commit" },
-]
 test = [
     { name = "hypothesis" },
     { name = "pytest" },
@@ -1737,7 +1734,6 @@ hyper = [
     { name = "optuna", specifier = ">=4.8.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
-lint = [{ name = "pre-commit", specifier = "==4.6.1" }]
 test = [
     { name = "hypothesis", specifier = ">=6.155.3" },
     { name = "pytest", specifier = ">=9.1.0" },


### PR DESCRIPTION
## Summary

`pre-commit==4.6.1` is already pinned in the `dev` dependency group, so the separate `lint` group only duplicated it. This removes the group and the check that required it.

- `pyproject.toml`: remove the `[dependency-groups] lint` entry
- `uv.lock`: refreshed accordingly
- `.rhiza/tests/test_pyproject.py`: drop `test_lint_group_present` and its docstring line

## Test plan

- `uv run --group test pytest .rhiza/tests/test_pyproject.py` — 23 passed
- pre-commit hooks pass on commit (including `uv-lock` and `Validate pyproject.toml`)

Note: `.rhiza/tests/test_pyproject.py` is template-managed, so the removed assertion may come back on the next `/rhiza:update` unless the template drops it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete lint dependency group from the project configuration.
  * Retained linting tools in the development dependency group.
* **Tests**
  * Updated dependency-group validation to reflect the current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->