### PR TITLE
fix: repair the core-install contract and close quality findings #889-#892

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,17 @@ portfolio-returning function scored by Sharpe ratio and returns a frozen `Study`
 
 ## Dependencies
 
-Core: `cvx-linalg`, `loguru`, `numpy>=2.0.0`, `jquantstats`, `optuna`, `polars`, `pydantic`, `pyyaml`
+Core (`[project].dependencies`, what `pip install tinycta` provides): `cvx-linalg`,
+`numpy>=2.0.0`, `polars>=1.43.0`, `pydantic`
+
+**Everything on the core import path must import only these four.** `tinycta.engine`
+imports `tinycta._kernel` at module level, so an import from the `hyper` extra anywhere
+outside `hyper/` breaks `pip install tinycta` — this is why `_kernel.py` does no logging.
+`tests/test_core_install.py` guards the contract; `deptry` cannot, because it accepts an
+import declared anywhere in the manifest, including in an extra.
+
+Hyper extra (`pip install "tinycta[hyper]"`, required by `tinycta.hyper` only):
+`jquantstats`, `loguru`, `optuna`, `pyyaml`
 
 Dev: `pre-commit`, `marimo`, `pandas`, `pandas-stubs`
 

--- a/src/tinycta/_kernel.py
+++ b/src/tinycta/_kernel.py
@@ -4,6 +4,12 @@ Every function here operates on NumPy arrays only — no Polars, no :class:`~tin
 — so the Polars-facing orchestration in :mod:`tinycta.engine` stays a thin adapter that
 prepares arrays, delegates the timestamp walk to :func:`forward_walk`, and writes the result
 back into a DataFrame.
+
+This module is on the core import path (``tinycta.engine`` imports it at module level), so it
+must import nothing outside ``[project].dependencies``. In particular it does **not** log:
+``loguru`` ships only with the optional ``hyper`` extra, and importing it here would break
+``pip install tinycta`` for every user who never asked for that extra. Degenerate cases are
+made observable through return values instead — see :func:`_risk_position`.
 """
 
 from __future__ import annotations
@@ -11,7 +17,6 @@ from __future__ import annotations
 from collections.abc import Hashable
 
 import numpy as np
-from loguru import logger
 
 from .linalg import inv_a_norm as _inv_a_norm
 from .linalg import solve as _solve
@@ -50,12 +55,6 @@ def _risk_position(corr: np.ndarray, mu_row: np.ndarray, mask: np.ndarray, shrin
     expected_mu = np.nan_to_num(mu_row[mask])
     denom = _inv_a_norm(expected_mu, matrix)
     if denom is None or not np.isfinite(denom) or _denominator_is_degenerate(denom) or np.allclose(expected_mu, 0.0):
-        logger.debug(
-            "Risk position zeroed for {} masked asset(s): degenerate correlation-norm "
-            "denominator (denom={}) or all-zero expected returns.",
-            int(mask.sum()),
-            denom,
-        )
         return np.zeros_like(expected_mu)
     return _solve(matrix, expected_mu) / denom
 

--- a/src/tinycta/config.py
+++ b/src/tinycta/config.py
@@ -4,7 +4,45 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 
 class Config(BaseModel):
-    """Configuration for correlation-aware position optimization (Basanos engine)."""
+    """Configuration for correlation-aware position optimization (Basanos engine).
+
+    Example:
+        >>> from pydantic import ValidationError
+        >>> from tinycta.config import Config
+        >>> cfg = Config(vola=32, corr=64, clip=4.2, shrink=0.5)
+        >>> cfg.vola, cfg.corr, cfg.clip, cfg.shrink
+        (32, 64, 4.2, 0.5)
+
+        The model is frozen, so a validated config cannot drift after construction:
+
+        >>> try:
+        ...     cfg.vola = 16
+        ... except ValidationError:
+        ...     print("frozen")
+        frozen
+
+        ``corr`` must not be shorter than ``vola`` — a correlation window below the
+        volatility window is numerically unstable:
+
+        >>> try:
+        ...     Config(vola=64, corr=32, clip=4.2, shrink=0.5)
+        ... except ValidationError:
+        ...     print("corr must be >= vola")
+        corr must be >= vola
+
+        Windows are strictly positive, ``shrink`` lies in ``[0, 1]``, and unknown
+        keys are rejected rather than silently ignored:
+
+        >>> for bad in ({"vola": 0}, {"shrink": 1.5}, {"typo": 1}):
+        ...     kwargs = {"vola": 32, "corr": 64, "clip": 4.2, "shrink": 0.5} | bad
+        ...     try:
+        ...         Config(**kwargs)
+        ...     except ValidationError:
+        ...         print("rejected", sorted(bad))
+        rejected ['vola']
+        rejected ['shrink']
+        rejected ['typo']
+    """
 
     vola: int = Field(..., gt=0)
     corr: int = Field(..., gt=0)

--- a/src/tinycta/hyper/_setup.py
+++ b/src/tinycta/hyper/_setup.py
@@ -11,7 +11,28 @@ _FILE_SINKS: dict[str, int] = {}
 
 
 class ExperimentConfig(NamedTuple):
-    """Resources bundled for a notebook experiment run."""
+    """Resources bundled for a notebook experiment run.
+
+    Example:
+        >>> from tinycta.hyper import ExperimentConfig
+        >>> cfg = ExperimentConfig(name="momentum", logger=None, params={"fast": 16, "slow": 64})
+        >>> cfg.name
+        'momentum'
+        >>> cfg.params
+        {'fast': 16, 'slow': 64}
+
+        The three config sections are optional and default to ``None``, so a
+        config file that omits one is not an error:
+
+        >>> cfg.optuna is None and cfg.data is None
+        True
+
+        Being a :class:`~typing.NamedTuple`, it also unpacks positionally:
+
+        >>> name, _logger, params, _optuna, _data = cfg
+        >>> name, sorted(params)
+        ('momentum', ['fast', 'slow'])
+    """
 
     name: str
     logger: Any
@@ -97,6 +118,44 @@ def get_config(name: str, config_path: Path | str | None = None) -> ExperimentCo
     ``NOTEBOOK_OUTPUT_FOLDER`` env var overrides the output directory used for
     the log file sink; otherwise the config-derived output directory is confined
     under the notebooks directory.
+
+    Example:
+        >>> import tempfile
+        >>> from pathlib import Path
+        >>> import yaml
+        >>> from tinycta.hyper import get_config
+
+        A shared ``config.yml`` supplies the sections directly:
+
+        >>> with tempfile.TemporaryDirectory() as tmp:
+        ...     config_path = Path(tmp) / "config.yml"
+        ...     _ = config_path.write_text(
+        ...         yaml.safe_dump({"params": {"fast": 16, "slow": 64}, "data": {"output_path": "out"}})
+        ...     )
+        ...     cfg = get_config("momentum", config_path=config_path)
+        ...     output_exists = (Path(tmp) / "out" / "momentum").is_dir()
+        >>> cfg.name
+        'momentum'
+        >>> cfg.params
+        {'fast': 16, 'slow': 64}
+
+        The output directory is created as a side effect, ready for the run's
+        artefacts and its ``output.log`` sink:
+
+        >>> output_exists
+        True
+
+        An ``output_path`` that would escape the notebooks directory is rejected
+        rather than followed:
+
+        >>> with tempfile.TemporaryDirectory() as tmp:
+        ...     config_path = Path(tmp) / "config.yml"
+        ...     _ = config_path.write_text(yaml.safe_dump({"data": {"output_path": "../../etc"}}))
+        ...     try:
+        ...         get_config("momentum", config_path=config_path)
+        ...     except ValueError:
+        ...         print("escaping output_path rejected")
+        escaping output_path rejected
     """
     config_path = Path(config_path) if config_path else Path.cwd() / "config.yml"
     cfg = _load_yaml(config_path)

--- a/src/tinycta/hyper/_study.py
+++ b/src/tinycta/hyper/_study.py
@@ -14,7 +14,41 @@ from loguru import logger
 
 @dataclass(frozen=True)
 class Study:
-    """Frozen wrapper around a completed Optuna study."""
+    """Frozen wrapper around a completed Optuna study.
+
+    Example:
+        >>> import optuna
+        >>> from tinycta.hyper import Study
+        >>> optuna.logging.set_verbosity(optuna.logging.WARNING)
+        >>> s = optuna.create_study(direction="maximize", sampler=optuna.samplers.TPESampler(seed=0))
+        >>> s.optimize(lambda trial: trial.suggest_float("x", 0.0, 1.0), n_trials=5)
+        >>> study = Study.from_optuna(s)
+        >>> study.n_trials, study.n_completed
+        (5, 5)
+        >>> sorted(study.best_params)
+        ['x']
+
+        ``str`` renders the best trial as a report block:
+
+        >>> print(study)  # doctest: +ELLIPSIS
+        === Best parameters ===
+          x            = 0...
+          Sharpe       = 0...
+          Completed    = 5 / 5 trials
+
+        A study in which every trial was pruned (each scored a NaN Sharpe) is not an
+        error — it reports no best parameters and a NaN best value:
+
+        >>> pruned = optuna.create_study(direction="maximize")
+        >>> pruned.optimize(
+        ...     lambda trial: (_ for _ in ()).throw(optuna.exceptions.TrialPruned()), n_trials=2
+        ... )
+        >>> empty = Study.from_optuna(pruned)
+        >>> empty.n_completed, empty.best_params
+        (0, {})
+        >>> print(empty)
+        No completed trials — all returned NaN Sharpe.
+    """
 
     best_params: dict[str, Any]
     best_value: float
@@ -107,7 +141,37 @@ def optimize(
     n_trials: int = 100,
     seed: int = 42,
 ) -> Study:
-    """Build objective, run study, log the summary and return a frozen Study."""
+    """Build objective, run study, log the summary and return a frozen Study.
+
+    ``suggest_portfolio_fn`` draws its parameters from the trial and returns a
+    portfolio; the trial is then scored by that portfolio's Sharpe ratio, which
+    the study maximises. A trial whose Sharpe is NaN is pruned rather than fatal.
+
+    Example:
+        >>> from types import SimpleNamespace
+        >>> from tinycta.hyper import optimize
+
+        Any object exposing ``.stats.sharpe()`` works here; in real use that is a
+        ``jquantstats`` ``Portfolio`` built from the strategy's returns:
+
+        >>> def portfolio(sharpe):
+        ...     return SimpleNamespace(stats=SimpleNamespace(sharpe=lambda: sharpe))
+
+        The objective is maximised, so the best value is the highest Sharpe seen —
+        here the reward peaks where ``fast`` is largest:
+
+        >>> study = optimize(lambda trial: portfolio(trial.suggest_int("fast", 1, 8)), n_trials=12)
+        >>> study.best_value
+        8.0
+        >>> study.best_params
+        {'fast': 8}
+
+        Runs are seeded, so the same objective and seed reproduce the same result:
+
+        >>> repeat = optimize(lambda trial: portfolio(trial.suggest_int("fast", 1, 8)), n_trials=12)
+        >>> repeat.best_params == study.best_params
+        True
+    """
     s = _run_study(_build_objective(suggest_portfolio_fn), n_trials=n_trials, seed=seed)
     study = Study.from_optuna(s)
     logger.info(str(study))

--- a/src/tinycta/signal.py
+++ b/src/tinycta/signal.py
@@ -37,6 +37,26 @@ def moving_absolute_deviation(x: pl.Expr, com: int = 32) -> pl.Expr:
 
     Returns:
         Polars expression of scaled rolling MAD values consistent with std under normality.
+
+    Example:
+        >>> import polars as pl
+        >>> from tinycta.signal import moving_absolute_deviation
+        >>> prices = pl.DataFrame({"A": [100.0, 101.5, 100.8, 103.2, 102.1, 105.0, 104.2, 107.5]})
+        >>> mad = prices.with_columns(moving_absolute_deviation(pl.col("A"), com=2).alias("mad"))
+
+        Two rolling medians of ``window = 2 * com - 1`` are chained over a log-return
+        series that itself starts one row late, so the estimate needs
+        ``2 * window - 1`` rows of returns before it emits a value:
+
+        >>> mad["mad"].null_count()
+        5
+        >>> float(mad["mad"][5]) > 0.0
+        True
+
+        The estimate is a dispersion, so it never goes negative:
+
+        >>> all(v >= 0.0 for v in mad["mad"][5:])
+        True
     """
     window = 2 * com - 1
     r = x.log(base=math.e).diff()
@@ -54,5 +74,29 @@ def shrink2id(matrix: np.ndarray, lamb: float = 1.0) -> np.ndarray:
 
     Returns:
         The resulting matrix after applying the shrinkage transformation.
+
+    Example:
+        >>> import numpy as np
+        >>> from tinycta.signal import shrink2id
+        >>> corr = np.array([[1.0, 0.8], [0.8, 1.0]])
+
+        ``lamb=1.0`` keeps the matrix as it is:
+
+        >>> shrink2id(corr, lamb=1.0)
+        array([[1. , 0.8],
+               [0.8, 1. ]])
+
+        ``lamb=0.0`` replaces it entirely with the identity:
+
+        >>> shrink2id(corr, lamb=0.0)
+        array([[1., 0.],
+               [0., 1.]])
+
+        In between, the unit diagonal is preserved and the off-diagonal
+        correlation is pulled towards zero in proportion to ``1 - lamb``:
+
+        >>> shrink2id(corr, lamb=0.5)
+        array([[1. , 0.4],
+               [0.4, 1. ]])
     """
     return matrix * lamb + (1 - lamb) * np.eye(N=matrix.shape[0])

--- a/src/tinycta/util.py
+++ b/src/tinycta/util.py
@@ -28,6 +28,30 @@ def vol_adj(x: pl.Expr, vola: int, clip: float, min_samples: int = 1) -> pl.Expr
 
     Returns:
         pl.Expr: Standardized and clipped log returns.
+
+    Example:
+        >>> import polars as pl
+        >>> from tinycta.util import vol_adj
+        >>> prices = pl.DataFrame({"A": [100.0, 102.0, 101.0, 104.0, 103.0, 106.0]})
+        >>> out = prices.with_columns(vol_adj(pl.col("A"), vola=3, clip=4.2).alias("adj"))
+
+        The first row has no log return and the second has no ``ewm_std`` (it is
+        undefined for a single observation), so the series starts on the third row:
+
+        >>> out["adj"].null_count()
+        2
+
+        Standardised returns keep the sign of the underlying move:
+
+        >>> [v > 0 for v in out["adj"][2:]]
+        [False, True, False, True]
+
+        ``clip`` bounds the output symmetrically, which is what keeps a single
+        volatility spike from dominating a downstream signal:
+
+        >>> tight = prices.with_columns(vol_adj(pl.col("A"), vola=3, clip=1.0).alias("adj"))
+        >>> all(-1.0 <= v <= 1.0 for v in tight["adj"][2:])
+        True
     """
     log_returns = x.log().diff()
     vol = log_returns.ewm_std(com=vola - 1, adjust=True, min_samples=min_samples)
@@ -50,5 +74,28 @@ def adj_log_prices(x: pl.Expr, vola: int, clip: float, min_samples: int = 1) -> 
     Returns:
         pl.Expr: Adjusted-log-price series obtained by cumulative sum of
             standardized returns.
+
+    Example:
+        >>> import polars as pl
+        >>> from tinycta.util import adj_log_prices, vol_adj
+        >>> prices = pl.DataFrame({"A": [100.0, 102.0, 101.0, 104.0, 103.0, 106.0]})
+        >>> out = prices.with_columns(
+        ...     vol_adj(pl.col("A"), vola=3, clip=4.2).alias("adj"),
+        ...     adj_log_prices(pl.col("A"), vola=3, clip=4.2).alias("level"),
+        ... )
+
+        The result is the running total of the standardised returns, so each level
+        is the previous one plus the current adjusted return:
+
+        >>> float(out["level"][2]) == float(out["adj"][2])
+        True
+        >>> round(float(out["level"][3]) - float(out["level"][2]), 12) == round(float(out["adj"][3]), 12)
+        True
+
+        ``cum_sum`` carries the leading nulls through, so the level series starts
+        where the adjusted returns do:
+
+        >>> out["level"].null_count()
+        2
     """
     return vol_adj(x, vola=vola, clip=clip, min_samples=min_samples).cum_sum()

--- a/tests/test_core_install.py
+++ b/tests/test_core_install.py
@@ -1,0 +1,222 @@
+"""Guard the core-install contract.
+
+``pip install tinycta`` provides only ``[project].dependencies``. The Optuna-based
+``tinycta.hyper`` layer and the four packages it needs (``jquantstats``, ``loguru``,
+``optuna``, ``pyyaml``) arrive only with ``pip install "tinycta[hyper]"``.
+
+Nothing else in the suite can see that contract break. ``[tool.uv]``
+``default-groups = ["dev", "hyper"]`` puts the extra into every dev and CI
+environment, and ``deptry`` treats an import as declared when it appears *anywhere*
+in the manifest — including in an extra. So a core module can import ``loguru``, as
+``_kernel.py`` once did, and `make fmt`, `make typecheck`, `make deptry`,
+`make security` and a 100%-coverage `make test` all stay green while
+``pip install tinycta`` ships an unimportable :class:`~tinycta.engine.Engine`.
+
+Two independent checks, because they fail in different directions:
+
+* :func:`test_core_modules_import_only_core_dependencies` reads the manifest and the
+  core modules' ASTs. Fast and hermetic, and it names the offending import.
+* :func:`test_core_modules_import_with_hyper_dependencies_absent` really imports every
+  core module in a subprocess where the hyper-only distributions are unimportable, so a
+  lazily-imported or dynamically-resolved dependency that the AST scan cannot see still
+  fails the suite.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = PROJECT_ROOT / "src" / "tinycta"
+PYPROJECT = PROJECT_ROOT / "pyproject.toml"
+
+# The subpackage that is allowed to import the `hyper` extra's dependencies.
+_OPTIONAL_SUBPACKAGE = "hyper"
+
+
+def _manifest() -> dict:
+    """Return the parsed ``pyproject.toml``."""
+    return tomllib.loads(PYPROJECT.read_text())
+
+
+def _normalize(dist: str) -> str:
+    """Normalise a distribution name per PEP 503 (lowercase, runs of -_. to -)."""
+    return re.sub(r"[-_.]+", "-", dist).lower()
+
+
+def _requirement_name(requirement: str) -> str:
+    """Return the bare distribution name from a PEP 508 requirement string."""
+    return _normalize(re.split(r"[\[<>=!~;\s]", requirement, maxsplit=1)[0])
+
+
+def _module_name_map() -> dict[str, str]:
+    """Return the normalised distribution -> import-module map from the deptry table.
+
+    Reusing ``[tool.deptry.package_module_name_map]`` keeps this test in step with the
+    manifest instead of hardcoding a second copy that can drift (``pyyaml`` imports as
+    ``yaml``, ``cvx-linalg`` as ``cvx``).
+    """
+    table = _manifest()["tool"]["deptry"]["package_module_name_map"]
+    return {_normalize(dist): module for dist, module in table.items() if module}
+
+
+def _modules_for(requirements: list[str]) -> set[str]:
+    """Return the top-level import names provided by ``requirements``."""
+    name_map = _module_name_map()
+    modules = set()
+    for requirement in requirements:
+        dist = _requirement_name(requirement)
+        modules.add(name_map.get(dist, dist.replace("-", "_")))
+    return modules
+
+
+def _core_dependency_modules() -> set[str]:
+    """Return the import names available from a bare ``pip install tinycta``."""
+    return _modules_for(_manifest()["project"]["dependencies"])
+
+
+def _hyper_only_modules() -> set[str]:
+    """Return the import names that arrive *only* with the ``hyper`` extra."""
+    extra = _manifest()["project"]["optional-dependencies"][_OPTIONAL_SUBPACKAGE]
+    return _modules_for(extra) - _core_dependency_modules()
+
+
+def _core_source_files() -> list[Path]:
+    """Return the source modules on the core import path (everything outside hyper/)."""
+    return sorted(p for p in SRC_ROOT.rglob("*.py") if _OPTIONAL_SUBPACKAGE not in p.relative_to(SRC_ROOT).parts)
+
+
+def _core_module_names() -> list[str]:
+    """Return the importable dotted names of the core modules."""
+    names = []
+    for path in _core_source_files():
+        rel = path.relative_to(SRC_ROOT).with_suffix("")
+        parts = [p for p in rel.parts if p != "__init__"]
+        names.append(".".join(["tinycta", *parts]))
+    return sorted(set(names))
+
+
+def _imported_top_level_modules(path: Path) -> set[str]:
+    """Return the top-level names imported by ``path``, excluding stdlib and self-imports.
+
+    Relative imports (``node.level > 0``) are intra-package and carry no external
+    dependency, so they are skipped.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    return {root for root in roots if root not in sys.stdlib_module_names and root != "tinycta"}
+
+
+def _render_offenders(offenders: dict[str, set[str]]) -> str:
+    """Render the offending file -> imports mapping as a stable, readable string."""
+    return "; ".join(f"{path} imports {', '.join(sorted(mods))}" for path, mods in sorted(offenders.items()))
+
+
+def test_core_modules_import_only_core_dependencies():
+    """No module outside ``tinycta.hyper`` may import a package missing from core deps.
+
+    This is the static half: it reads the manifest, walks each core module's AST and
+    reports any third-party import that a bare ``pip install tinycta`` would not supply.
+    """
+    allowed = _core_dependency_modules()
+
+    offenders: dict[str, set[str]] = {}
+    for path in _core_source_files():
+        stray = _imported_top_level_modules(path) - allowed
+        if stray:
+            offenders[str(path.relative_to(PROJECT_ROOT))] = stray
+
+    assert not offenders, (
+        "core modules import packages absent from [project].dependencies, so "
+        f"`pip install tinycta` cannot import them: {_render_offenders(offenders)}"
+    )
+
+
+def test_hyper_extra_actually_supplies_something_beyond_core():
+    """The hyper extra must contribute imports core lacks, or these tests prove nothing.
+
+    If the extra were folded into core, :func:`_hyper_only_modules` would go empty and
+    the subprocess test below would block nothing while still passing.
+    """
+    assert _hyper_only_modules(), (
+        "the `hyper` extra adds no packages beyond [project].dependencies — the core-install guard would be vacuous"
+    )
+
+
+def test_core_modules_import_with_hyper_dependencies_absent():
+    """Every core module imports when the hyper extra's packages are unimportable.
+
+    Runs in a subprocess with a ``sys.meta_path`` finder that raises
+    :class:`ModuleNotFoundError` for the hyper-only distributions, reproducing a bare
+    ``pip install tinycta`` without building a wheel or touching the network.
+    """
+    blocked = sorted(_hyper_only_modules())
+    modules = _core_module_names()
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _IMPORT_UNDER_BLOCKADE, json.dumps(blocked), json.dumps(modules)],
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+        timeout=60,
+    )
+
+    if completed.returncode != 0:
+        pytest.fail(f"import probe failed to run: {completed.stderr.strip()}")
+
+    failures = json.loads(completed.stdout)
+    assert not failures, (
+        f"core modules fail to import without the `hyper` extra ({', '.join(blocked)} blocked): " + "; ".join(failures)
+    )
+
+
+# Executed by the test above via ``python -c``. Kept dependency-free and stdlib-only so
+# it runs in the blockaded interpreter; arguments arrive as JSON on argv.
+_IMPORT_UNDER_BLOCKADE = '''
+import importlib
+import importlib.abc
+import json
+import sys
+
+blocked = set(json.loads(sys.argv[1]))
+modules = json.loads(sys.argv[2])
+
+
+class _Blockade(importlib.abc.MetaPathFinder):
+    """Make the hyper-only distributions look absent, as on a core-only install."""
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".")[0] in blocked:
+            raise ModuleNotFoundError("No module named " + repr(fullname), name=fullname)
+        return None
+
+
+# Drop anything already imported so the blockade applies on re-import.
+for name in list(sys.modules):
+    if name.split(".")[0] in blocked or name.split(".")[0] == "tinycta":
+        del sys.modules[name]
+
+sys.meta_path.insert(0, _Blockade())
+
+failures = []
+for name in modules:
+    try:
+        importlib.import_module(name)
+    except BaseException as exc:
+        failures.append(name + ": " + type(exc).__name__ + ": " + str(exc))
+
+print(json.dumps(failures))
+'''

--- a/tests/tinycta/test__kernel.py
+++ b/tests/tinycta/test__kernel.py
@@ -10,7 +10,6 @@ through the Polars orchestration layer.
 from __future__ import annotations
 
 import numpy as np
-from loguru import logger
 
 from tinycta._kernel import _denominator_is_degenerate, _risk_position, _update_profit_variance
 
@@ -50,25 +49,21 @@ class TestRiskPosition:
         assert pos[0] > 0.0
         assert pos[1] == 0.0
 
-    def test_all_zero_mu_returns_zeros_and_logs_reason(self):
-        """All-zero expected returns yield a zero position and a debug reason.
+    def test_all_zero_mu_returns_zeros(self):
+        """All-zero expected returns yield an exactly-zero position, not a silent NaN.
 
-        The degenerate/all-zero fallback must be observable (zeros + a logged
-        reason), not a silent NaN.
+        The degenerate/all-zero fallback is observable through the return value
+        alone: the kernel deliberately does not log, because it sits on the core
+        import path and ``loguru`` ships only with the optional ``hyper`` extra.
         """
         corr = np.eye(2)
         mu_row = np.zeros(2)
         mask = np.array([True, True])
 
-        captured: list[str] = []
-        sink_id = logger.add(captured.append, level="DEBUG", format="{message}")
-        try:
-            pos = _risk_position(corr, mu_row, mask, shrink=0.5)
-        finally:
-            logger.remove(sink_id)
+        pos = _risk_position(corr, mu_row, mask, shrink=0.5)
 
         assert np.array_equal(pos, np.zeros(2))
-        assert any("Risk position zeroed for 2 masked asset(s)" in m for m in captured)
+        assert not np.isnan(pos).any()
 
     def test_mask_restricts_the_solve_to_tradable_assets(self):
         """Only masked-in assets appear in the returned position."""


### PR DESCRIPTION
Closes #889, #890, #891, #892 — the four findings from the `/rhiza:quality` run.

## The defect

`pip install tinycta` shipped an unimportable `Engine`. `src/tinycta/_kernel.py` imported `loguru` at module level, but `loguru` is declared only in the `hyper` optional extra — and `cvx-linalg` pulls in just `numpy`, so it was not available transitively. `engine.py` imports `_kernel` at module level, so both modules failed:

```
OK   tinycta, tinycta.osc, tinycta.ewma, tinycta.util,
     tinycta.signal, tinycta.config, tinycta.linalg, tinycta.ewm_cov
FAIL tinycta._kernel -> ModuleNotFoundError: No module named 'loguru'
FAIL tinycta.engine  -> ModuleNotFoundError: No module named 'loguru'
```

`README.md:43` promises the opposite: *"The core install keeps a minimal dependency footprint (numpy, polars, pydantic, cvx-linalg)."*

## Why every gate stayed green

Three things lined up:

- `deptry` treats an import as declared if it appears **anywhere** in the manifest, extras included — so no DEP001.
- `[tool.uv] default-groups = ["dev", "hyper"]` puts `loguru` into every dev and CI environment.
- Nothing tested the package the way an end user installs it.

Commit `2a26d58` had earlier resolved the one CI job that would have surfaced this by adding the deps to the *test environment*. Its message states the intent — "end users still get a minimal core from `pip install tinycta`" — which the import silently defeated. `CLAUDE.md:86` still listed `loguru` as core, consistent with the code, which is plausibly why it stayed invisible.

## The changes

**#889 — core-install contract.** Dropped the `logger.debug` call and the import from `_kernel.py`, keeping the core footprint at the four packages the README advertises. The degenerate/all-zero fallback stays observable through the returned zeros, which is what the test asserted anyway. The module docstring now records why the core import path must stay dependency-clean.

**#891 — regression guard.** New `tests/test_core_install.py` checks the contract two independent ways:

- a static AST scan of every module outside `hyper/` against `[project].dependencies`, which names the offending file and import;
- a real subprocess import of all core modules with the hyper-only distributions blocked by a `sys.meta_path` finder — catching a lazy or dynamic import the AST scan cannot see.

Both were verified to fail when the `loguru` import is reintroduced:

```
AssertionError: core modules fail to import without the `hyper` extra
(jquantstats, loguru, optuna, yaml blocked):
tinycta._kernel: ModuleNotFoundError: No module named 'loguru';
tinycta.engine: ModuleNotFoundError: No module named 'loguru'
```

A third test asserts the extra actually contributes packages beyond core, so the guard cannot quietly become vacuous.

**#890 — documentation drift.** `CLAUDE.md` listed `loguru`, `jquantstats`, `optuna` and `pyyaml` as core. Corrected the split, and recorded the invariant plus why `deptry` cannot enforce it. `README.md:43` was already accurate and needed no change.

**#892 — executable documentation.** Added runnable examples to `signal.py`, `util.py`, `config.py`, `hyper/_setup.py` and `hyper/_study.py`. Docstring examples go from **20 across 3 objects to 93 across 12**; `make rhiza-test` executes all of them. The `get_config` example also demonstrates the path-traversal rejection, and the `Config` example the frozen/`extra="forbid"`/`corr >= vola` validation.

## Verification

All gates pass:

| Gate | Result |
|---|---|
| `make fmt` | PASS |
| `make typecheck` | PASS — `ty` + `mypy --strict`, 13 files |
| `make docs-coverage` | PASS — 350/350, 100% |
| `make deptry` | PASS |
| `make security` | PASS |
| `make rhiza-test` | PASS — 40 tests, doctests included |
| `make test` | PASS — **160 passed**, 100% statement+branch |
| test-layout parity | PASS |
| doc examples (`--run`) | PASS — 93 examples, 0 violations |

The core install was verified against a freshly built wheel with `--no-cache`: all ten public modules now import, `tinycta.engine` included.

Note on #891's acceptance criterion: it was written as "fails when loguru is removed from `[project].dependencies`", assuming the fix would add loguru to core. Since the chosen fix keeps core minimal instead, the equivalent guarantee is that the test fails when a core module *imports* a hyper-only package — which is what was verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
