### PR TITLE
docs: add executable examples to _kernel.py and Engine.cor

### DIFF
--- a/src/tinycta/_kernel.py
+++ b/src/tinycta/_kernel.py
@@ -50,6 +50,41 @@ def _risk_position(corr: np.ndarray, mu_row: np.ndarray, mask: np.ndarray, shrin
 
     Returns:
         np.ndarray: The normalised risk position over the masked assets.
+
+    Example:
+        >>> import numpy as np
+        >>> from tinycta._kernel import _risk_position
+        >>> both = np.array([True, True])
+
+        With an identity correlation the solve is trivial: the asset carrying the
+        expected return takes the whole (unit-norm) position and the other takes none.
+
+        >>> _risk_position(np.eye(2), np.array([1.0, 0.0]), both, shrink=1.0)
+        array([1., 0.])
+
+        A correlated pair tilts against the correlation — holding the second asset
+        short hedges the first, and the norm stays unit under the shrunk metric:
+
+        >>> corr = np.array([[1.0, 0.8], [0.8, 1.0]])
+        >>> _risk_position(corr, np.array([1.0, 0.0]), both, shrink=0.5).round(4)
+        array([ 1.0911, -0.4364])
+
+        An all-zero ``mu`` is degenerate and falls back to zeros rather than
+        dividing by a vanishing normaliser:
+
+        >>> _risk_position(np.eye(2), np.array([0.0, 0.0]), both, shrink=1.0)
+        array([0., 0.])
+
+        ``NaN`` expected returns are tolerated — they are zeroed, not propagated:
+
+        >>> _risk_position(np.eye(2), np.array([1.0, np.nan]), both, shrink=1.0)
+        array([1., 0.])
+
+        The result spans only the masked assets, so an untradable asset is absent
+        from the output rather than present as a zero:
+
+        >>> _risk_position(corr, np.array([1.0, 2.0]), np.array([True, False]), shrink=1.0)
+        array([1.])
     """
     matrix = _shrink2id(corr, lamb=shrink)[np.ix_(mask, mask)]
     expected_mu = np.nan_to_num(mu_row[mask])
@@ -81,6 +116,28 @@ def _update_profit_variance(
 
     Returns:
         float: The updated profit-variance estimate.
+
+    Example:
+        >>> import numpy as np
+        >>> from tinycta._kernel import _update_profit_variance
+        >>> both = np.array([True, True])
+
+        A position of 2.0 against a 10% return realises a profit of 0.2, so the
+        estimate decays towards ``0.2 ** 2`` by ``1 - lamb``:
+
+        >>> _update_profit_variance(1.0, np.array([2.0, 0.0]), np.array([0.1, 0.0]), both, lamb=0.99)
+        0.9904
+
+        A flat book realises nothing, so the estimate simply decays:
+
+        >>> _update_profit_variance(1.0, np.array([0.0, 0.0]), np.array([0.1, 0.2]), both, lamb=0.99)
+        0.99
+
+        ``NaN`` on either side is zeroed rather than poisoning the estimate — here
+        the second asset contributes nothing and the result matches the first case:
+
+        >>> _update_profit_variance(1.0, np.array([2.0, np.nan]), np.array([0.1, 0.5]), both, lamb=0.99)
+        0.9904
     """
     lhs = np.nan_to_num(cash_pos_prev[ret_mask], nan=0.0)
     rhs = np.nan_to_num(returns_row[ret_mask], nan=0.0)
@@ -116,6 +173,44 @@ def forward_walk(
         cash_pos_np: Output cash-position buffer, mutated in place.
         row_of: Map from a ``cor`` key back to its row index.
         shrink: Identity-shrinkage weight in ``[0, 1]`` passed to :func:`_risk_position`.
+
+    Example:
+        >>> import numpy as np
+        >>> from tinycta._kernel import forward_walk
+        >>> prices = np.array([[100.0, 50.0], [101.0, 50.5], [102.0, 50.0]])
+        >>> returns = np.zeros_like(prices)
+        >>> returns[1:] = prices[1:] / prices[:-1] - 1.0
+        >>> mu = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
+        >>> vola = np.full((3, 2), 0.1)
+        >>> risk_pos = np.full((3, 2), np.nan)
+        >>> cash_pos = np.full((3, 2), np.nan)
+
+        Only rows named by ``cor`` are walked; here the first row is warmup and is
+        left untouched. The function returns nothing and writes into the buffers:
+
+        >>> forward_walk(
+        ...     {1: np.eye(2), 2: np.eye(2)},
+        ...     prices, returns, mu, vola, risk_pos, cash_pos,
+        ...     row_of={1: 1, 2: 2},
+        ...     shrink=1.0,
+        ... ) is None
+        True
+        >>> risk_pos[0]
+        array([nan, nan])
+
+        The first walked row starts from a profit variance of 1.0, so its risk
+        position is the raw solve, and the cash position divides it by volatility:
+
+        >>> risk_pos[1]
+        array([1., 0.])
+        >>> cash_pos[1]
+        array([10.,  0.])
+
+        By the next row the realised P&L has updated the profit-variance estimate,
+        which rescales the position:
+
+        >>> risk_pos[2].round(4)
+        array([1.01, 0.  ])
     """
     profit_variance = 1.0
     lamb = 0.99

--- a/src/tinycta/engine.py
+++ b/src/tinycta/engine.py
@@ -84,6 +84,50 @@ class Engine:
             - **NaN cells:** a cell is ``NaN`` while either asset is still in its
               own warmup, and a zero-variance asset (``outer == 0``) yields ``NaN``
               correlations rather than a divide-by-zero.
+
+        Example:
+            >>> import math
+            >>> import polars as pl
+            >>> from tinycta.config import Config
+            >>> from tinycta.engine import Engine
+            >>> dates = list(range(1, 11))
+            >>> prices = pl.DataFrame(
+            ...     {
+            ...         "date": dates,
+            ...         "A": [100.0, 101.5, 100.8, 102.3, 103.1, 102.0, 104.5, 105.2, 104.1, 106.0],
+            ...         "B": [50.0, 49.2, 50.4, 49.8, 51.1, 50.3, 49.5, 50.8, 51.6, 50.9],
+            ...     }
+            ... )
+            >>> mu = pl.DataFrame({"date": dates, "A": [0.1] * 10, "B": [-0.05] * 10})
+            >>> cfg = Config(vola=3, corr=3, clip=4.2, shrink=0.5)
+            >>> cor = Engine(prices=prices, mu=mu, cfg=cfg).cor
+
+            The first ``cfg.corr + 1`` timestamps are omitted, so the mapping is
+            keyed by the surviving dates rather than by position:
+
+            >>> sorted(cor)
+            [5, 6, 7, 8, 9, 10]
+
+            Each value is a correlation matrix with a unit diagonal:
+
+            >>> mat = cor[5]
+            >>> mat.shape
+            (2, 2)
+            >>> [round(float(v), 6) for v in mat.diagonal()]
+            [1.0, 1.0]
+            >>> bool(-1.0 <= mat[0, 1] <= 1.0)
+            True
+
+            A zero-variance asset yields ``NaN`` rather than a divide-by-zero. Here
+            ``B`` never moves, so every cell touching it is ``NaN`` while ``A`` keeps
+            its unit diagonal:
+
+            >>> flat = prices.with_columns(pl.lit(50.0).alias("B"))
+            >>> flat_cor = Engine(prices=flat, mu=mu, cfg=cfg).cor[5]
+            >>> math.isnan(flat_cor[1, 1]), math.isnan(flat_cor[0, 1])
+            (True, True)
+            >>> round(float(flat_cor[0, 0]), 6)
+            1.0
         """
         cov = _ewm_covariance(
             self.ret_adj,


### PR DESCRIPTION
Closes #894.

## Why

`make docs-coverage` reports 100% because a docstring *exists*. Nothing checked
whether what it *claims* is still true — the documentation failure with the
longest half-life, since a stale example keeps rendering perfectly.

A `/rhiza:quality` run found the package's 93 doctests concentrated in 8 of 13
modules, with the two carrying the most intricate contracts covered by prose
alone:

- **`_kernel.py`** — the pure-NumPy numeric core. A degenerate-denominator
  fallback, an EWMA profit-variance recursion and an in-place forward walk, all
  described but never demonstrated.
- **`Engine.cor`** — a warmup and `NaN` contract spanning ten lines of docstring
  (`engine.py:78–87`) with nothing asserting either half.

## What changed

Docstrings only. **No logic touched** — the diff is entirely inside `"""` blocks.

| Object | Examples added |
| --- | --- |
| `_risk_position` | identity solve; correlated tilt (short hedge against a positive `mu`); all-zero-`mu` fallback to zeros; `NaN` tolerance; result spans **only** masked assets, so an untradable asset is absent rather than a zero |
| `_update_profit_variance` | the EWMA recursion on a realised 0.2 profit (`0.9904`); pure decay on a flat book (`0.99`); `NaN` on either side zeroed rather than poisoning the estimate |
| `forward_walk` | returns `None` and mutates in place; unwalked warmup rows stay `NaN`; `cash == risk / vola`; the next row rescaled by the updated profit variance |
| `Engine.cor` | the first `cfg.corr + 1` timestamps are omitted and the mapping is keyed by **date, not position** (`sorted(cor) == [5, 6, 7, 8, 9, 10]`); a zero-variance asset yields `NaN` rather than a divide-by-zero, while its counterpart keeps a unit diagonal |

That second `Engine.cor` case is the one the `np.divide(..., where=outer > 0)`
masking at `engine.py:102` exists to prevent — it now has a test behind it.

## Verification

| Gate | Result |
| --- | --- |
| `make rhiza-test` | 40 passed — `test_docstrings.py` runs `doctest.testmod` over every module |
| `make test` | 160 passed, coverage still **100%** statement and branch |
| `make typecheck` | `ty` + `mypy --strict` clean |
| `make fmt` | 21 hooks pass |
| `check_doc_examples.py` | exit 0, **0 violations**, examples **93 → 140** |

`_kernel.py` now holds 3 of the 16 example locations and `Engine.cor` 18
examples, so every substantive prose claim in the package has an executable
check behind it.

One example needed a correction while verifying: `flat_cor[0, 0]` evaluates to
`1.0000000000000002`, not `1.0`, so it is asserted via `round(float(...), 6)`
rather than pinning a fragile float repr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added executable examples documenting risk-position calculations, profit variance updates, and forward-walk behavior.
  * Documented handling of edge cases, including degenerate inputs, missing values, masking, warmup rows, and in-place outputs.
  * Expanded correlation documentation with examples covering warmup periods, date keys, unit diagonals, and zero-variance assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->