### PR TITLE
docs: correct the stale project-structure paths in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,11 @@ uv run pytest tests/tinycta/test_osc.py::test_name -v
     - `_setup.py` - `get_config()` / `ExperimentConfig` notebook experiment setup helpers
 - `tests/tinycta/` - Package tests
 - `tests/property/` - Hypothesis property-based tests
+- `tests/fuzz/` - Atheris fuzz targets (`fuzz_signal.py`), built by `.clusterfuzzlite/build.sh`
+  and driven by the `rhiza_fuzzing` workflow; not collected by `make test`
 - `.rhiza/tests/` - Rhiza framework infrastructure tests
-- `book/` - Documentation source
+- `docs/` - Documentation source (`index.md`, `tutorial.md`, `api/`, `development/`);
+  built by `make book` via the root `mkdocs.yml`
 - `.rhiza/` - Rhiza framework scripts and configurations
 
 ## Architecture Notes
@@ -95,7 +98,7 @@ import declared anywhere in the manifest, including in an extra.
 Hyper extra (`pip install "tinycta[hyper]"`, required by `tinycta.hyper` only):
 `jquantstats`, `loguru`, `optuna`, `pyyaml`
 
-Dev: `pre-commit`, `marimo`, `pandas`, `pandas-stubs`
+Dev: `pre-commit`, `marimo`, `pandas`, `pandas-stubs`, `types-PyYAML`
 
 Test: `pytest`, `pytest-cov`, `pytest-html`, `pytest-mock`, `pytest-xdist`, `pytest-timeout`,
 `hypothesis`, `pytest-benchmark`


### PR DESCRIPTION
Closes #896 — the single finding from the latest `/rhiza:quality` run.

`CLAUDE.md` is the file that tells contributors, and Claude Code, where things live in this repo, so a stale path there costs more than the same typo elsewhere. Three inaccuracies, all documentation-only — no source is touched.

## 1. `book/` did not exist

The Project Structure section named a `book/` directory that is not in the repo. The documentation source is `docs/` (`index.md`, `tutorial.md`, `api/`, `development/`), built by `make book` via the root `mkdocs.yml` — confirmed by `mkdocs.yml:8` (`docs_dir: docs`) and `.rhiza/make.d/book.mk:50`.

## 2. `tests/fuzz/` was undocumented

The section listed `tests/tinycta/`, `tests/property/` and `.rhiza/tests/` but omitted `tests/fuzz/`. Described from the harness itself (`tests/fuzz/fuzz_signal.py`): Atheris fuzz targets, built by `.clusterfuzzlite/build.sh` and driven by the `rhiza_fuzzing` workflow. Also noted as not collected by `make test`, since the filename does not match pytest's `test_*.py` — worth stating so nobody concludes the suite is running when it isn't.

## 3. The Dev dependency list was one entry short

`types-PyYAML>=6.0` is declared in `[dependency-groups].dev` (`pyproject.toml:45`) but was missing from the list.

## Verification

`make fmt` passes, markdownlint included. Nothing else in the repo changes, so the rest of the gate run stands: all nine gates passed at template `v1.3.3`, with 100% statement-and-branch coverage and average CC 2.54 (A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)