### PR TITLE
docs: drop retired .rhiza paths from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,9 @@ uv run pytest tests/tinycta/test_osc.py::test_name -v
     - `_setup.py` - `get_config()` / `ExperimentConfig` notebook experiment setup helpers
 - `tests/tinycta/` - Package tests
 - `tests/property/` - Hypothesis property-based tests
-- `.rhiza/tests/` - Rhiza framework infrastructure tests
 - `docs/` - Documentation source (`index.md`, `tutorial.md`, `api/`, `development/`);
   built by `make book` via the root `mkdocs.yml`
-- `.rhiza/` - Rhiza framework scripts and configurations
+- `.rhiza/` - Rhiza template config (`template.yml`, `template.lock`) and shared policy docs
 
 ## Architecture Notes
 
@@ -105,6 +104,9 @@ Managed via `uv add` and `pyproject.toml`.
 
 ## Rhiza Framework
 
-This project uses the Rhiza framework for standardized Python development. The main Makefile includes
-`.rhiza/rhiza.mk` which provides common targets. Do not modify `.rhiza/` files directly - they are
+This project uses the Rhiza framework for standardized Python development. Tasks and gates run
+through `uv run rhiza-task <task>`; the root `Makefile` is a template-owned shim that forwards to
+it, so `make test` and `make book` keep working. Repo-specific targets go in `local.mk`, and the
+settings where this repo departs from the CLI defaults live in `[tool.rhiza-task]` in
+`pyproject.toml`. Do not modify `.rhiza/` files or the `Makefile` directly - they are
 template-managed.


### PR DESCRIPTION
`CLAUDE.md` still described the repo as it looked two rhiza releases ago. Three claims in it are false against the current tree:

- **`.rhiza/tests/` is listed as a source tree.** rhiza v1.4.x moved the bundled checks out of that directory and into the [pytest-rhiza](https://github.com/jebel-quant/pytest-rhiza) package this repo pins in `[tool.rhiza-task]`. The directory does not exist.
- **The Rhiza Framework section says the Makefile includes `.rhiza/rhiza.mk`.** The make layer was retired in v1.4.0 (see #901) and that file is gone. The root `Makefile` is a template-owned shim that forwards to `uv run rhiza-task <task>`.
- **`.rhiza/` is described as holding "scripts and configurations".** It tracks `template.yml`, `template.lock` and the shared policy docs — no scripts.

This replaces them with what is actually there, and names `rhiza-task`, `local.mk` and `[tool.rhiza-task]` as the places that now matter. Documentation only; no code, config or gate is touched.

Same class of fix as tschm/pyhrp#789, which corrected the one stale citation in that repo's `mkdocs.yml`. I checked the other five rhiza repos alongside this one — every remaining `.rhiza/tests` mention in them (`docs/development/TESTS.md`, `pytest.ini`, `ruff.toml`, the changelogs, funnel's `.rhiza/history`) is deliberately past-tense and correct as written. This file was the last place presenting the path as current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project-structure documentation to clarify template configuration and policy files.
  * Added guidance for using `rhiza-task`, the Makefile integration, `local.mk`, and related settings.
  * Simplified the documented project structure by removing a separate framework-tests entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->